### PR TITLE
Update classes for new Discord update

### DIFF
--- a/scss/main/_channels.scss
+++ b/scss/main/_channels.scss
@@ -4,7 +4,7 @@
 @use "../top/msgPill" as msg;
 
 // Channels sidebar
-.sidebar_a4d4d9 {
+.sidebar_c48ade {
     @include channels.vars;
     @include boxes.box($position: absolute);
     bottom: 0;
@@ -29,55 +29,55 @@
     }
 
     // Server channels
-    .container_ee69e0,
+    .container__2637a,
     // DMs
-    .privateChannels_f0963d {
+    .privateChannels__35e86 {
         padding-left: 28px;
     }
 }
 
 // Header
-:not(.bannerVisible_fd6364) > .header_fd6364 {
+:not(.bannerVisible_f37cb1) > .header_f37cb1 {
     @include boxes.clickable;
     box-shadow: none;
 }
 
-.clickable_fd6364 .header_fd6364:hover,
-.selected_fd6364 .header_fd6364 {
+.clickable_f37cb1 .header_f37cb1:hover,
+.selected_f37cb1 .header_f37cb1 {
     background: unset;
 }
 
 // Find or start a conversation
-.searchBar_f0963d .searchBarComponent_f0963d {
+.searchBar__35e86 .searchBarComponent__35e86 {
     @include boxes.clickable;
     color: $black;
 }
 
 // Unread DM message
-.highlighted_f9647d {
+.highlighted__20a53 {
     @include msg.unreadPill($size: 8px);
     color: $black;
 
-    :is(.interactive_f5eb4b:focus-within, .interactive_f5eb4b:hover) & {
+    :is(.interactive_bf202d:focus-within, .interactive_bf202d:hover) & {
         color: $white;
     }
 }
 
 // Public server indicator
-.communityInfoPill_fd6364 {
+.communityInfoPill_f37cb1 {
     @include boxes.box;
     z-index: 1;
 }
 
 // Boost goal
-.container_c75f85 {
+.container_eff079 {
     margin: 2px;
 
-    .goalText_c75f85 {
+    .goalText_eff079 {
         color: var(--channels-default) !important;
     }
 
-    .progressBarContainer_c75f85 {
+    .progressBarContainer_eff079 {
         @include boxes.inset;
     }
 
@@ -86,45 +86,45 @@
     }
 }
 
-.sectionDivider_c43953 {
+.sectionDivider__629e4 {
     display: none;
 }
 
 // Channel group
-.wrapper_a08117:is(.muted_a08117:hover, :hover) :is(.icon_a08117, .name_a08117),
-.privateChannelsHeaderContainer_c47fa9:hover :is(.headerText_c47fa9, .privateChannelRecipientsInviteButtonIcon_c47fa9) {
+.wrapper__29444:is(.muted__29444:hover, :hover) :is(.icon__29444, .name__29444),
+.privateChannelsHeaderContainer__99e7c:hover :is(.headerText__99e7c, .privateChannelRecipientsInviteButtonIcon__99e7c) {
     color: var(--channels-default);
 }
 
 // Add channel button
-.addButton_a08117 {
+.addButton__29444 {
     width: 20px;
     height: 20px;
 
-    .addButtonIcon_a08117:hover {
+    .addButtonIcon__29444:hover {
         color: var(--channels-default);
     }
 }
 
 // Channel
 .container_b15955,
-.wrapper_d8bfb3 {
+.wrapper__2ea32 {
     margin-left: 0;
 }
 
 // Channel actions
-.children_d8bfb3 {
+.children__2ea32 {
     margin-top: 2px;
 }
-.iconItem_f6f816 {
+.iconItem_c69b6d {
     margin-left: 0;
 
-    .actionIcon_f6f816 {
+    .actionIcon_c69b6d {
         @include boxes.clickable;
         background: var(--background-secondary);
     }
 
-    &:hover .actionIcon_f6f816 {
+    &:hover .actionIcon_c69b6d {
         color: var(--channels-default);
     }
 
@@ -134,13 +134,13 @@
 }
 
 // Show all VC button
-.voiceChannelsButton_a08117 {
+.voiceChannelsButton__29444 {
     @include boxes.clickable;
     color: var(--channels-default);
 }
 
 // Unread bubble
-.unreadImportant_d8bfb3 {
+.unreadImportant__2ea32 {
     background: var(--channels-default);
     z-index: 1;
     left: 0;
@@ -148,46 +148,46 @@
 
 // Channels: black on none bg
 :is(
-        .modeConnected_d8bfb3,
-        .modeUnreadImportant_d8bfb3:not(:hover),
-        .notInteractive_d8bfb3.modeConnected_d8bfb3,
-        .notInteractive_d8bfb3.modeSelected_d8bfb3
-    ) {
-    .name_d8bfb3 {
+    .modeConnected__2ea32,
+    .modeUnreadImportant__2ea32:not(:hover),
+    .notInteractive__2ea32.modeConnected__2ea32,
+    .notInteractive__2ea32.modeSelected__2ea32
+) {
+    .name__2ea32 {
         color: var(--channels-default);
     }
 }
 
 // Muted channels: grey on none bg
-.modeMuted_d8bfb3 .icon_d8bfb3,
-.modeMuted_d8bfb3 .name_d8bfb3 {
+.modeMuted__2ea32 .icon__2ea32,
+.modeMuted__2ea32 .name__2ea32 {
     color: $darkgrey;
 }
 
 // Hovered and selected channels: white on navy bg
-:is(.modeMuted_d8bfb3:hover, .wrapper_d8bfb3:hover, .modeConnected_d8bfb3:hover, .modeSelected_d8bfb3, .modeSelected_d8bfb3:hover) {
-    :is(.icon_d8bfb3, .name_d8bfb3) {
+:is(.modeMuted__2ea32:hover, .wrapper__2ea32:hover, .modeConnected__2ea32:hover, .modeSelected__2ea32, .modeSelected__2ea32:hover) {
+    :is(.icon__2ea32, .name__2ea32) {
         color: var(--interactive-hover);
     }
 
-    .unreadImportant_d8bfb3 {
+    .unreadImportant__2ea32 {
         background: var(--interactive-hover);
     }
 }
 
 // Voice user
-.voiceUser_cdc675:is(:hover, :active) {
-    :is(.username_cdc675, .icon_cdc675) {
+.voiceUser__07f91:is(:hover, :active) {
+    :is(.username__07f91, .icon__07f91) {
         color: var(--interactive-hover);
     }
 }
 
-.usernameSpeaking_cdc675 {
+.usernameSpeaking__07f91 {
     color: var(--channels-default);
 }
 
 // Drag voice user
-.containerUserOver_f6f816::after {
+.containerUserOver_c69b6d::after {
     background: $darkblue;
     opacity: 0.3;
     border-color: $darkblue;
@@ -196,8 +196,8 @@
 
 // Drag channel before
 // Drag channel after
-.containerDragBefore_f6f816::before,
-.containerDragAfter_f6f816::after {
+.containerDragBefore_c69b6d::before,
+.containerDragAfter_c69b6d::after {
     background: $darkblue;
     left: 0;
 }

--- a/scss/main/_channelsandroles.scss
+++ b/scss/main/_channelsandroles.scss
@@ -2,36 +2,36 @@
 @use "../top/boxes" as boxes;
 
 // Tabs
-.tabBar_f1fd9c {
+.tabBar__0b563 {
     margin: 0 16px;
     border-bottom: 0;
 
-    .tabBarItem_f1fd9c {
+    .tabBarItem__0b563 {
         padding-bottom: 8px;
     }
 }
 
 // Customise
-.appMount_ea7e65 .scrollerContainer_c6b11b {
+.appMount__51fd7 .scrollerContainer_c6b11b {
     background: $bg;
     @include boxes.inset;
 }
 
-.pageBody_c6b11b h2 {
+.pageBody__5d7c9 h2 {
     color: $text !important;
 }
 
-.prompt_c6b11b {
+.prompt__5d7c9 {
     background: $bg;
     border-color: unset !important;
     padding: 0;
 }
 
-.promptOptions_c6b11b {
+.promptOptions__5d7c9 {
     gap: 0;
 }
 
-.optionButtonWrapper_bd5e1f {
+.optionButtonWrapper__270d7 {
     background: $grey;
     @include boxes.clickable;
 
@@ -43,40 +43,40 @@
         border-color: $black $white $white $black;
     }
 
-    &.pressed_bd5e1f {
+    &.pressed__270d7 {
         transform: none;
     }
 
-    &.selected_bd5e1f {
+    &.selected__270d7 {
         @include boxes.inset;
 
-        .checkIcon_bd5e1f {
+        .checkIcon__270d7 {
             top: 4px;
             right: 4px;
         }
     }
 }
 
-.helpText_c6b11b {
+.helpText__5d7c9 {
     .text-xs-medium__220aa {
         color: $text !important;
     }
 }
 
 // Browse channels
-.pageBody_c2efea {
+.pageBody__41ed7 {
     padding-left: 0;
 }
 
-.browser_c2efea {
+.browser__41ed7 {
     background: $bg;
     @include boxes.scroller;
 }
 
-.selectAll_f04d06 .checkboxWrapper_f6cde8 .checkbox_f6cde8 {
+.selectAll_e4503a .checkboxWrapper_f525d3 .checkbox_f525d3 {
     border-color: var(--text-muted) !important;
 
-    &.checked_f6cde8 path {
+    &.checked_f525d3 path {
         fill: var(--text-muted);
     }
 }

--- a/scss/main/_chatbox.scss
+++ b/scss/main/_chatbox.scss
@@ -2,71 +2,71 @@
 @use "../top/boxes" as boxes;
 
 // Chat box
-.channelTextArea_a7d72e {
+.channelTextArea_f75fb0 {
     @include boxes.inset;
 
     // Buttons
-    .buttonContainer_d0696b,
-    .attachButton_f298d4,
-    .buttonContainer_a06035 {
+    .buttonContainer__74017,
+    .attachButton__0923f,
+    .buttonContainer_aa63ab {
         @include boxes.clickable;
         background: $grey;
     }
-    @at-root .has-webkit-scrollbar .buttons_d0696b {
+    @at-root .has-webkit-scrollbar .buttons__74017 {
         margin-right: 0;
     }
 
-    .separator_a06035 {
+    .separator_aa63ab {
         margin-left: unset;
 
         &::before {
             display: none;
         }
 
-        .innerButton_a06035 {
+        .innerButton_aa63ab {
             margin: 6px;
         }
 
-        .button_a06035:focus-within .activeButtonChild_a06035,
-        .button_a06035:focus .activeButtonChild_a06035,
-        .button_a06035:hover .activeButtonChild_a06035,
-        .button_a06035 .activeButtonChild_a06035 {
+        .button_aa63ab:focus-within .activeButtonChild_aa63ab,
+        .button_aa63ab:focus .activeButtonChild_aa63ab,
+        .button_aa63ab:hover .activeButtonChild_aa63ab,
+        .button_aa63ab .activeButtonChild_aa63ab {
             color: var(--text-brand);
         }
     }
 
     // Attachment area divider
-    .divider_fc5f50 {
+    .divider__908e2 {
         display: none;
     }
 
     // Attachments
-    .channelAttachmentArea_e8c527 {
+    .channelAttachmentArea_b77158 {
         padding: 4px;
         margin: 0;
         gap: 4px;
 
-        .upload_df1eaf {
+        .upload_aa605f {
             padding: 0;
         }
 
         // Attachment preview
-        .uploadContainer_df1eaf {
+        .uploadContainer_aa605f {
             @include boxes.box;
             flex-direction: column-reverse;
         }
 
         // Attachment controls
-        .actionBar_df1eaf {
+        .actionBar_aa605f {
             transform: none;
             right: 4px;
             top: 4px;
 
-            .wrapper_ef319f {
+            .wrapper_f7ecac {
                 height: 17px;
             }
 
-            .button_ef319f {
+            .button_f7ecac {
                 @include boxes.clickable;
                 height: 16px;
                 width: 16px;
@@ -76,34 +76,34 @@
         }
 
         // Filename
-        .filenameContainer_f847a3 {
+        .filenameContainer__41ea0 {
             @include boxes.winBar($text: "");
             margin-top: 0;
 
-            .filename_f847a3 {
+            .filename__41ea0 {
                 margin-top: 0;
                 color: $grey;
             }
         }
 
         // Attachment image
-        .mediaContainer_f847a3 {
+        .mediaContainer__41ea0 {
             margin: auto 0;
         }
 
-        .icon_f847a3.code_f847a3 {
+        .icon__41ea0.code__41ea0 {
             background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAx0lEQVRYR+1XWxaEIAiVnbkzdWe6MicK54xHezDxkYk/ESGP6yUPYNqVSQXLU1JGf82qlN777JwzIYTVUFpe/KPbKub3pQQHAJPzVriUjAVh8BijsdZWSTwvgd453dWllNbKLyFwN1hv/3gJIPl6q5Cz205E3t+9xX4OBI64Mx4C0p0wHgL/dIFyQBSBvSPgkvN9PyJFQBGYBwFupWf27MtI7wJF4IxU3O+XSIhOcT6k2Y0b49B+bypqJlXyUkZy0STIWTNwfABE/48wR04ubgAAAABJRU5ErkJggg==")
                 center no-repeat;
         }
     }
 
     // Typing area
-    .slateTextArea_e52116 {
+    .slateTextArea_ec4baf {
         padding-left: 10px;
     }
 
     // Autocomplete
-    .autocomplete_f23da8 {
+    .autocomplete__13533 {
         @include boxes.box($position: absolute);
         bottom: calc(100% + 17px);
         left: -1px;
@@ -116,31 +116,31 @@
             border-bottom-color: $grey;
         }
 
-        .scroller_bea0d0 {
+        .scroller__6b0e0 {
             padding-bottom: 1px;
         }
 
         // Entry
-        .autocompleteRow_f23da8 .base_f23da8 {
+        .autocompleteRow__13533 .base__13533 {
             @include boxes.clickable;
         }
 
-        .autocompleteRow_f23da8[aria-selected="true"] .base_f23da8 {
+        .autocompleteRow__13533[aria-selected="true"] .base__13533 {
             @include boxes.inset;
         }
 
         // Divider
-        .divider_f23da8 {
+        .divider__13533 {
             display: none;
         }
 
         // Members matching title
-        .contentTitle_f23da8 strong {
+        .contentTitle__13533 strong {
             color: $black;
         }
 
         // Bot list
-        .rail_fe2299 {
+        .rail_d1405b {
             @include boxes.box;
             margin-bottom: 0;
             width: 48px;
@@ -149,42 +149,42 @@
                 border-bottom: 0;
             }
 
-            .listItems_dcade6 {
+            .listItems_affa7e {
                 inset: 7px !important;
             }
 
-            .section_efd8e6 {
+            .section_b1e4f3 {
                 margin-bottom: 0;
             }
 
-            .selectable_a69fe5,
-            .selectable_c9d951 {
+            .selectable_ca5f52,
+            .selectable__1a58a {
                 @include boxes.clickable;
             }
 
-            .builtInSeparator_efd8e6 {
+            .builtInSeparator_b1e4f3 {
                 display: none;
             }
         }
 
         // Bot command group
-        .categoryHeader_fe2299 {
+        .categoryHeader_d1405b {
             background: $grey;
             z-index: 2;
             border-bottom: 1px solid $darkgrey;
         }
 
         // Command required args
-        .option_bea3ee {
+        .option_a19535 {
             @include boxes.thin;
             background: $grey;
         }
 
         // Command optional args
-        .optionals_e18e73 {
+        .optionals__920ab {
             @include boxes.thin;
             padding: 0 4px;
-            .optionalCount_e18e73 {
+            .optionalCount__920ab {
                 padding: 0;
             }
         }
@@ -192,9 +192,9 @@
 }
 
 // Under chat box
-.base_d7ebeb {
+.base_b88801 {
     // Slowmode
-    .cooldownWrapper_d7ebeb {
+    .cooldownWrapper_b21699 {
         color: $black !important;
     }
 }

--- a/scss/main/_forums.scss
+++ b/scss/main/_forums.scss
@@ -2,21 +2,21 @@
 @use "../top/boxes" as boxes;
 
 // Channel header
-.forumOrHome_ff5f90 {
+.forumOrHome__49676 {
     --__header-bar-background: #{$grey};
 }
 
 // Tags
-.pill_c993da {
+.pill_a2c9e8 {
     @include boxes.clickable;
     background: $grey;
-    &.selected_c993da {
+    &.selected_a2c9e8 {
         @include boxes.inset;
     }
 }
 
 // Main container
-.container_a6d69a {
+.container_f369db {
     @include boxes.inset;
     background: $bg;
 
@@ -25,10 +25,10 @@
     --bg-mod-subtle: none;
 
     // Post tags
-    @at-root .tags_f451cd {
+    @at-root .tags__08166 {
         gap: 0;
 
-        & > :is(.pinIcon_f451cd, .tagPill_a57509) {
+        & > :is(.pinIcon__08166, .tagPill__9a337) {
             @include boxes.box;
             background: $grey;
 
@@ -39,12 +39,12 @@
     }
 
     // New post bubble
-    @at-root .newPostsButton_a6d69a {
+    @at-root .newPostsButton_f369db {
         z-index: 2;
     }
 
     // Wrapper around everything
-    .content_eed6a8 {
+    .content__99f8c {
         padding-left: 24px;
         padding-right: 24px;
 
@@ -55,7 +55,7 @@
             left: 0 !important;
             width: 100% !important;
 
-            .headerRow_a6d69a {
+            .headerRow_f369db {
                 left: 0 !important;
                 width: inherit !important;
             }
@@ -67,51 +67,51 @@
         }
 
         // Tag area in text posts
-        .textContentFooter_a57509 {
+        .textContentFooter__9a337 {
             background: transparent;
         }
     }
 
     // Everything but post cards
-    .headerRow_a6d69a {
+    .headerRow_f369db {
         padding: 0;
         background: $grey;
 
         // Filter by tags bar
-        .tagsContainer_a6d69a {
+        .tagsContainer_f369db {
             @include boxes.box;
             background: $grey;
             padding: 2px 12px;
 
             // Sort and view dropdown
-            .sortDropdown_a6d69a {
+            .sortDropdown_f369db {
                 margin-bottom: 0;
                 &[aria-expanded="true"] {
                     @include boxes.inset;
                 }
             }
 
-            .divider_a6d69a {
+            .divider_f369db {
                 display: none;
             }
 
-            .tagListInner_a6d69a {
+            .tagListInner_f369db {
                 gap: 0;
             }
         }
 
         // Matching post count bar
-        .matchingPostsRow_a6d69a {
+        .matchingPostsRow_f369db {
             @include boxes.box;
         }
 
         // Search/create posts bar
-        .mainCard_a6d69a {
+        .mainCard_f369db {
             margin-top: 0;
             @include boxes.box;
 
             // Search button and guidelines button
-            :is(.prefixElement_c1668f, .guidelinesButton_d7afe7) {
+            :is(.prefixElement_d9be46, .guidelinesButton_d7afe7) {
                 @include boxes.clickable;
                 display: flex;
                 justify-content: center;
@@ -128,52 +128,52 @@
             }
 
             // Post message
-            .contentContainer_c1668f {
+            .contentContainer_d9be46 {
                 padding-left: 32px;
 
                 div {
                     background: $bg;
 
-                    .channelTextArea_d0696b {
+                    .channelTextArea__74017 {
                         width: auto;
                     }
                 }
             }
 
             // Post attachments
-            .container_a15d29 {
+            .container__94439 {
                 align-self: flex-end;
 
-                .uploadInput_a15d29 {
+                .uploadInput__94439 {
                     @include boxes.clickable;
                     height: 76px;
                     width: 76px;
                 }
 
                 // Attachment not image type
-                .icon_f847a3 {
+                .icon__41ea0 {
                     @include boxes.box;
                 }
 
                 // Attachment is image type
-                .mediaContainer_f847a3 > div:not([aria-expanded="false"]),
-                .mediaContainer_f847a3 > div:not([aria-expanded="false"]) > div {
+                .mediaContainer__41ea0 > div:not([aria-expanded="false"]),
+                .mediaContainer__41ea0 > div:not([aria-expanded="false"]) > div {
                     max-height: 76px;
                     max-width: 76px;
 
-                    .imageSmall_f847a3 {
+                    .imageSmall__41ea0 {
                         height: 76px;
                     }
                 }
 
                 // Number of attachments
-                .badge_a15d29 {
+                .badge__94439 {
                     z-index: 1;
                     background: $darkblue;
                 }
 
                 // Attachments popout
-                .popoutContainer_a15d29 {
+                .popoutContainer__94439 {
                     z-index: 1;
                     @include boxes.box($position: absolute);
                     padding: 0;
@@ -181,7 +181,7 @@
                     right: -8px;
 
                     // Scroller
-                    .popout_a15d29 {
+                    .popout__94439 {
                         padding-bottom: 0;
 
                         &::-webkit-scrollbar-track,
@@ -191,7 +191,7 @@
                         }
 
                         // Attachment controls
-                        .actionBarContainer_df1eaf {
+                        .actionBarContainer_aa605f {
                             z-index: 2;
                         }
                     }
@@ -199,26 +199,26 @@
             }
 
             // Create post button
-            .submitButton_c1668f {
+            .submitButton_d9be46 {
                 height: 30px;
             }
 
             // Divider
-            .tagsDivider_c1668f {
+            .tagsDivider_d9be46 {
                 display: none;
             }
 
             // Post tags
-            .tagsContainer_c1668f {
+            .tagsContainer_d9be46 {
                 margin-left: 8px;
                 margin-top: 0px;
-                .tagListInner_c1668f {
+                .tagListInner_d9be46 {
                     gap: 0;
                 }
             }
 
             // Post bar
-            .controlsContainer_c1668f {
+            .controlsContainer_d9be46 {
                 justify-content: flex-start;
                 gap: 0;
                 margin-top: 0;
@@ -231,12 +231,12 @@
                     width: 30px;
                 }
 
-                .controls_c1668f {
+                .controls_d9be46 {
                     flex-grow: initial;
                     gap: 0;
 
                     // Slowmode warning
-                    .wrappedControls_c1668f {
+                    .wrappedControls_d9be46 {
                         order: 1;
                         padding-left: 4px;
                     }
@@ -247,15 +247,15 @@
 }
 
 // Post card
-li.card_a6d69a {
+li.card_f369db {
     padding: 0;
     margin: 8px;
     @include boxes.clickable;
     background: $grey;
 }
 
-:is(.container_d331f1, .container_a57509) {
-    .markup_f8f345 {
+:is(.container_faa96b, .container__9a337) {
+    .markup__75297 {
         color: var(--text-normal);
     }
 
@@ -264,7 +264,7 @@ li.card_a6d69a {
         transform: none;
     }
 
-    &:not(.isOpen_d331f1, .isOpen_a57509) {
+    &:not(.isOpen_faa96b, .isOpen__9a337) {
         &:is(:hover, :active) {
             background: $grey;
         }
@@ -276,42 +276,42 @@ li.card_a6d69a {
         }
     }
 
-    &:is(.isOpen_d331f1, .isOpen_a57509) {
+    &:is(.isOpen_faa96b, .isOpen__9a337) {
         @include boxes.inset;
     }
 
     // Post content preview
-    .thumbnailContainer_d331f1,
-    .contentPreview_a57509,
-    .bodyMedia_a57509 {
+    .thumbnailContainer_faa96b,
+    .contentPreview__9a337,
+    .bodyMedia__9a337 {
         @include boxes.inset;
     }
 
     // Text content
-    .contentPreview_a57509 {
+    .contentPreview__9a337 {
         background: $bg;
 
-        .markup_f8f345 {
+        .markup__75297 {
             color: $text;
         }
     }
 }
 
 // Opened post
-.scrollerInner_e2e187 {
+.scrollerInner__36d07 {
     overflow: unset;
 
     // Post alert options bar
-    .container_b385c8 {
+    .container__34c2c {
         @include boxes.box;
         position: sticky;
         top: 0;
 
-        .buttons_b385c8 {
+        .buttons__34c2c {
             gap: 0;
 
-            @at-root .addReactButton_b385c8,
-                .buttonInner_b385c8 {
+            @at-root .addReactButton__34c2c,
+                .buttonInner__34c2c {
                 @include boxes.clickable;
                 height: 20px;
 
@@ -324,6 +324,6 @@ li.card_a6d69a {
 }
 
 // OP post and post replies divider
-.divider_af45f8 {
+.divider_ee23ac {
     display: none;
 }

--- a/scss/main/_friends.scss
+++ b/scss/main/_friends.scss
@@ -2,19 +2,19 @@
 @use "../top/boxes" as boxes;
 
 // Titlebar
-.children_e44302 {
+.children__9293f {
     overflow: visible;
 
-    .topPill_a0 {
+    .topPill_b3f026 {
         position: relative;
         top: 12px;
         left: 10px;
 
-        .item_a0 {
+        .item_b3f026 {
             @include boxes.tab;
             margin: 0;
 
-            &.selected_a0 {
+            &.selected_b3f026 {
                 text-decoration: underline;
             }
         }
@@ -22,10 +22,10 @@
 }
 
 // Online / All / Pending / Blocked / Add Friend
-.peopleColumn_c2739c {
+.peopleColumn__133bf {
     @include boxes.inset;
 
-    .searchBar_e0840f {
+    .searchBar__5ec2f {
         @include boxes.inset;
         background: $bg;
         color: $text;
@@ -42,21 +42,21 @@
         }
     }
 
-    .title_a1cafe {
+    .title__1472a {
         margin: 8px 12px 4px;
     }
 
-    .peopleList_e0840f {
+    .peopleList__5ec2f {
         margin: 0 8px 8px;
         padding-bottom: 0;
         @include boxes.inset;
 
-        .peopleListItem_d51464 {
+        .peopleListItem_cc6179 {
             margin: 0;
             padding: 8px;
             @include boxes.clickable;
 
-            .actionButton_e01b91 {
+            .actionButton_f8fa06 {
                 @include boxes.clickable;
                 height: 24px;
                 width: 24px;
@@ -68,42 +68,42 @@
         }
     }
 
-    .header_c96274 {
+    .header__94b08 {
         border-bottom: 0;
     }
 
-    .header_c96274,
-    .header_aef5fd {
+    .header__94b08,
+    .header_a14595 {
         padding: 8px;
     }
 
     // Other places to make friends
-    .grid_aef5fd {
+    .grid_a14595 {
         padding: 0 8px;
         gap: 8px;
 
-        .container_aef5fd {
+        .container_a14595 {
             @include boxes.clickable;
         }
     }
 
     // Add friend
-    .addFriendInputWrapper_de812f {
+    .addFriendInputWrapper__72ba7 {
         padding: 0;
 
-        .addFriendInput_de812f {
+        .addFriendInput__72ba7 {
             margin-right: 0;
         }
     }
 }
 
 // Friend activity
-.nowPlayingColumn_c2739c {
-    .scroller_bf550a {
+.nowPlayingColumn__133bf {
+    .scroller__7d20c {
         @include boxes.scroller;
         padding: 0 !important;
 
-        .header_bf550a {
+        .header__7d20c {
             position: sticky;
             top: 0;
             margin: 0 0 8px;
@@ -113,7 +113,7 @@
             z-index: 2;
         }
 
-        .itemCard_f02fcf {
+        .itemCard__7e549 {
             @include boxes.clickable;
             margin: 0 8px;
             padding: 12px;
@@ -122,7 +122,7 @@
                 background: $grey;
             }
 
-            .body_cd82a7 {
+            .body__00943 {
                 @include boxes.inset;
             }
         }
@@ -130,11 +130,11 @@
 }
 
 // Message requests
-.list_f3abf4 {
+.list_f391e3 {
     @include boxes.scroller;
     padding: 8px !important;
 
-    .content_eed6a8 > div:first-child {
+    .content__99f8c > div:first-child {
         display: none;
     }
 
@@ -145,16 +145,16 @@
         margin-bottom: 8px;
     }
 
-    .messageRequestItem_a5de62 {
+    .messageRequestItem_abb9ad {
         @include boxes.clickable;
 
-        .messageContent_f9f2ca {
+        .messageContent_c19a55 {
             color: $black;
         }
     }
 }
 
 // If empty
-.content_a7d72e:has(.emptyStateContainer_c353e6) {
+.content_f75fb0:has(.emptyStateContainer__65428) {
     @include boxes.inset;
 }

--- a/scss/main/_headerbar.scss
+++ b/scss/main/_headerbar.scss
@@ -3,34 +3,34 @@
 
 // Header bars
 :is(
-        .container_c2739c .container_e44302,
-        .container_fca846 .container_e44302,
-        .pageWrapper_a3a4ce .scroller_a3a4ce,
-        .scroller_a39aa3 .viewWrapper_a39aa3,
-        .applicationStore_cecc86 .homeWrapper_d175a8,
-        .container_d1c246:not(.floating_d1c246) .container_e44302:not(.wrapper_d880dc .container_e44302),
-        .chat_a7d72e .container_e44302:not(.wrapper_d880dc .container_e44302)
-    ) {
+    .container__133bf .container__9293f,
+    .container__808a1 .container__9293f,
+    .pageWrapper_a3a4ce .scroller_a3a4ce,
+    .scroller_a39aa3 .viewWrapper_a39aa3,
+    .applicationStore_f07d62 .homeWrapper__0920e,
+    .container__01ae2:not(.floating__01ae2) .container__9293f:not(.wrapper_cb9592 .container__9293f),
+    .chat_f75fb0 .container__9293f:not(.wrapper_cb9592 .container__9293f)
+) {
     margin-top: $title-height;
     z-index: 0;
 
-    .divider_e44302 {
+    .divider__9293f {
         display: none;
     }
 }
 
 // End of description shadow
-.appMount_ea7e65 :is(.innerHeader_f1fd9c, .headerBarInner_e85cee)::after {
+.appMount__51fd7 :is(.innerHeader__0b563, .headerBarInner__7449f)::after {
     background: linear-gradient(180deg, transparent, $grey);
 }
 
 // Tools
-.toolbar_e44302 {
-    .search_ff5f90 {
+.toolbar__9293f {
+    .search__49676 {
         @include boxes.inset;
         margin: 0;
 
-        .searchBar_a46bef {
+        .searchBar__97492 {
             height: 30px;
             align-items: center;
             background: $bg;
@@ -41,18 +41,18 @@
             }
 
             // Search button
-            .icon_a46bef {
+            .icon__97492 {
                 @include boxes.clickable;
                 background: $grey;
 
-                .icon_effbe2 {
+                .icon_fea832 {
                     color: $black;
                 }
             }
 
             // Filters
-            .searchFilter_b0fa94,
-            .searchAnswer_b0fa94 {
+            .searchFilter_bd8186,
+            .searchAnswer_bd8186 {
                 @include boxes.box;
                 background: $grey;
                 color: $black;
@@ -61,10 +61,10 @@
     }
 
     // Buttons
-    .videoControls_dd069c
+    .videoControls_bfe55a
         &
-        .iconWrapper_e44302.clickable_e44302:is(.anchor_af404b .iconWrapper_e44302:only-of-type, :has([d^="M14 8.00598"])),
-    .iconWrapper_e44302.clickable_e44302:not(.anchor_af404b .iconWrapper_e44302:only-of-type, :has([d^="M14 8.00598"])) {
+        .iconWrapper__9293f.clickable__9293f:is(.anchor_edefb8 .iconWrapper__9293f:only-of-type, :has([d^="M14 8.00598"])),
+    .iconWrapper__9293f.clickable__9293f:not(.anchor_edefb8 .iconWrapper__9293f:only-of-type, :has([d^="M14 8.00598"])) {
         @include boxes.clickable;
         margin: 0;
         height: 32px;
@@ -80,6 +80,6 @@
 }
 
 // Under header bar
-.content_a7d72e::before {
+.content_f75fb0::before {
     display: none;
 }

--- a/scss/main/_index.scss
+++ b/scss/main/_index.scss
@@ -22,17 +22,17 @@
 @use "../top/shortcutIcon" as sc;
 
 // Overall background
-.bg_d4b6c5 {
+.bg__960e4 {
     background: var(--w9x-background-color) var(--w9x-background-image) center/cover;
 }
 
 // Transparency
-:is(.appMount_ea7e65, body, .app_a01fb1) {
+:is(.appMount__51fd7, body, .app__160d8) {
     background: transparent;
 }
 
 // Put notice banners below main window
-.base_a4d4d9 {
+.base_c48ade {
     flex-direction: column-reverse;
     height: calc(100% - var(--server-container));
 
@@ -40,29 +40,29 @@
         z-index: 102;
     }
 
-    :is(.bd-notice, .notice_dd5a33, .notice__5fd4c) {
+    :is(.bd-notice, .notice_c5cd6a, .notice__5fd4c) {
         @include boxes.box;
         margin-bottom: -4px;
 
-        .back_dd5a33 {
+        .back_c5cd6a {
             position: absolute;
         }
     }
 }
 
 // Settings
-.standardSidebarView_c25c6d,
+.standardSidebarView__23e6b,
 // Main DM and friend list view
-.container_c2739c,
+.container__133bf,
 // Explore servers view
 .pageWrapper_a3a4ce,
 // Student hub
 .scroller_a39aa3,
 // Buy Nitro page
-.applicationStore_cecc86,
+.applicationStore_f07d62,
 // Server subscriptions
-.container_fca846,
+.container__808a1,
 // Main chat
-.chat_a7d72e:not(.container_f1fd9c > .chat_a7d72e) {
+.chat_f75fb0:not(.container__0b563 > .chat_f75fb0) {
     @include boxes.mainWindow();
 }

--- a/scss/main/_members.scss
+++ b/scss/main/_members.scss
@@ -3,7 +3,7 @@
 @use "../top/channellist-css" as channels;
 
 // Members list
-.container_cbd271 {
+.container_c8ffbb {
     @include channels.vars;
     @include boxes.box;
     @include boxes.winBar($isPseudo: true, $text: "Members");
@@ -17,15 +17,15 @@
 }
 
 // Members list scroller
-.members_cbd271 {
+.members_c8ffbb {
     margin-top: $title-height;
 
     // Member
-    .member_a31c43 {
+    .member__5d473 {
         margin-left: 4px;
 
         // Custom status or activity
-        &:is(:hover, .selected_e9f61e) .activityText_a31c43 {
+        &:is(:hover, .selected__91a9d) .activityText__5d473 {
             color: var(--interactive-hover);
         }
     }

--- a/scss/main/_messages.scss
+++ b/scss/main/_messages.scss
@@ -2,54 +2,54 @@
 @use "../top/boxes" as boxes;
 
 // Chat message display area
-.messagesWrapper_e2e187 {
+.messagesWrapper__36d07 {
     margin-bottom: 24px;
     @include boxes.inset;
     background: $bg;
 }
 
 // Placeholder messages
-.wrapper_ba0ffb,
-.wrapper_b211c6 {
+.wrapper__0d1ef,
+.wrapper_fc8177 {
     background: $bg;
 }
 
 // Jump to present bar and other bottom bars
-.barBase_cf58b5 {
+.barBase__0f481 {
     right: 18px;
     left: 0;
     padding-bottom: 0;
 }
 
 // With members list visible
-.base_a4d4d9:has(.membersWrap_cbd271) {
+.base_c48ade:has(.membersWrap_c8ffbb) {
     // VC video controls
-    .bottomControls_dd069c {
+    .bottomControls_bfe55a {
         width: auto;
         padding-right: 150px;
     }
 
     // Message
-    .message_d5deea {
+    .message__5126c {
         padding-right: 140px !important;
 
         // Message actions
-        .container_a3b500 {
+        .container__040f0 {
             right: 130px;
         }
     }
 }
 
 // Message actions
-.wrapper_ef319f {
+.wrapper_f7ecac {
     height: auto;
 
-    .button_ef319f {
+    .button_f7ecac {
         @include boxes.clickable;
         padding: 0;
 
-        &.disabled_ef319f,
-        &.disabled_ef319f:hover {
+        &.disabled_f7ecac,
+        &.disabled_f7ecac:hover {
             @include boxes.box;
             padding: 0;
         }
@@ -57,68 +57,68 @@
 }
 
 // Text
-.description_c2668b,
-.markup_f8f345,
-.container_e62b38,
-.header_c2668b,
-.username_f9f2ca,
-.repliedTextPlaceholder_f9f2ca,
-.repliedTextPreview_f9f2ca.clickable_f9f2ca:hover,
-.repliedMessage_f9f2ca,
-.subtitle_ec583a,
-.markup_f8f345 code,
-.codeBlockText_cdb578,
-.codeLine_cdb578,
-.operations_ed9386,
-.markup_f8f345 h1,
-.markup_f8f345 h2,
-.markup_f8f345 h3,
-.markup_f8f345 h4,
-.markup_f8f345 h5,
-.markup_f8f345 h6 {
+.description__00de6,
+.markup__75297,
+.container__235ca,
+.header__00de6,
+.username_c19a55,
+.repliedTextPlaceholder_c19a55,
+.repliedTextPreview_c19a55.clickable_c19a55:hover,
+.repliedMessage_c19a55,
+.subtitle__54b20,
+.markup__75297 code,
+.codeBlockText_ada32f,
+.codeLine_ada32f,
+.operations_bab751,
+.markup__75297 h1,
+.markup__75297 h2,
+.markup__75297 h3,
+.markup__75297 h4,
+.markup__75297 h5,
+.markup__75297 h6 {
     color: $text;
 }
 
 // Eyebrow
 .eyebrow_e5a66c,
-.eyebrow_c46f6a {
+.eyebrow_b717a1 {
     text-transform: none;
 }
 
 // Blockquote
-.blockquoteDivider_f8f345 {
+.blockquoteDivider__75297 {
     background: $grey;
 }
 
 // Bullet point
-.markup_f8f345 li {
+.markup__75297 li {
     list-style-type: square;
 }
 
 // Attachments
-.spoilerInnerContainer_a3d0f7,
+.spoilerInnerContainer__54ab5,
 .messageAttachment__5dae1 .wrapperAudio_f316dd,
-.embedWrapper_b558d0.container_ad9cbd,
-.attachment_a4623d,
-.gridContainer_ad0b71,
-.tile_ab47a1,
-.wrapper_b9fe76,
+.embedWrapper_b7e1cb.container__4d95d,
+.fileWrapper__0ccae,
+.gridContainer__623de,
+.tile__72090,
+.wrapper_d5f3cd,
 .imageWrapper__178ee {
     @include boxes.box;
 }
 
 // Remove attachments
-.embedSuppressButton_ad0b71,
-.embedSuppressButton_ad0b71:hover {
+.embedSuppressButton__623de,
+.embedSuppressButton__623de:hover {
     color: $text;
 }
 
 // Text attachments
-.newMosaicStyle_ad9cbd .codeView_ad9cbd {
+.newMosaicStyle__4d95d .codeView__4d95d {
     margin: 0;
 }
 
-.textContainer_ad9cbd {
+.textContainer__4d95d {
     @include boxes.inset;
     background: $bg;
 
@@ -128,20 +128,20 @@
     }
 }
 
-.downloadButton_ad9cbd {
+.downloadButton__4d95d {
     @include boxes.clickable;
     padding: 0;
     margin-top: 5px;
     margin-left: 6px;
 }
 
-.codeIcon_ad9cbd {
+.codeIcon__4d95d {
     @include boxes.clickable;
     padding: 0;
 }
 
 // Central play pause video button
-.iconWrapper_b26897 {
+.iconWrapper__6eb54 {
     @include boxes.clickable;
     opacity: 1;
     background: $grey;
@@ -150,7 +150,7 @@
 
 // Download / delete / alt txt button
 .hoverButton_be4802,
-.mediaMosaicAltText_cf58b5 {
+.mediaMosaicAltText__0f481 {
     @include boxes.clickable;
 
     &:active,
@@ -162,7 +162,7 @@
 }
 
 // Embed source site
-.embedProvider_ad0b71 {
+.embedProvider__623de {
     color: var(--text-normal);
 }
 
@@ -177,8 +177,8 @@
 }
 
 // Fullscreen button
-.controlIcon_ef18ee,
-.controlIcon_ef18ee:hover {
+.controlIcon_f1ceac,
+.controlIcon_f1ceac:hover {
     color: $black;
 }
 
@@ -223,51 +223,51 @@
 }
 
 // Reactions
-.reaction_ec6b19 {
+.reaction__23977 {
     margin-right: 0;
     border: 0;
 }
 
-.reactionInner_ec6b19 {
+.reactionInner__23977 {
     @include boxes.box;
 }
 
 // Self reactions
-.reaction_ec6b19.reactionMe_ec6b19 {
+.reaction__23977.reactionMe__23977 {
     background: $grey;
 }
 
 // Clicked reactions
-.reactionMe_ec6b19 .reactionInner_ec6b19,
-.reactionInner_ec6b19:active {
+.reactionMe__23977 .reactionInner__23977,
+.reactionInner__23977:active {
     @include boxes.inset;
 
-    .reactionCount_ec6b19 {
+    .reactionCount__23977 {
         color: $black;
     }
 }
 
 // Hovered reactions
-.reaction_ec6b19:hover {
-    .reactionCount_ec6b19 {
+.reaction__23977:hover {
+    .reactionCount__23977 {
         color: $black;
     }
 }
 
 // Add more reactions button
-.reactionBtn_ec6b19:is(:hover, :active) {
-    .icon_ec6b19 {
+.reactionBtn__23977:is(:hover, :active) {
+    .icon__23977 {
         color: $text;
     }
 }
 
 // Open thread button
-.container_c15230 {
+.container__9271d {
     @include boxes.clickable;
 }
 
 // Links
-.content_e62b38 a {
+.content__235ca a {
     color: var(--text-link);
 }
 
@@ -283,50 +283,50 @@
 }
 
 // Spoiler text
-.messageContent_f9f2ca {
-    .spoilerMarkdownContent_a3d0f7.hidden_a3d0f7 {
+.messageContent_c19a55 {
+    .spoilerMarkdownContent__54ab5.hidden__54ab5 {
         @include boxes.box;
         background: $darkgrey;
     }
 
-    .spoilerMarkdownContent_a3d0f7 {
+    .spoilerMarkdownContent__54ab5 {
         @include boxes.inset;
         background: $bg;
     }
 }
 
 // Code blocks
-.markup_f8f345 code {
+.markup__75297 code {
     @include boxes.box;
     background: $bg;
 }
 
 // Editors
-.editor_a552a6 {
+.editor__1b31f {
     caret-color: $text;
 }
 
 // Polls
-.container_a1531c {
+.container__0be77 {
     @include boxes.box;
     background: $grey;
 
     --control-brand-foreground: #{$black};
 
     // Option
-    .answer_cf2c85 {
+    .answer__4c520 {
         @include boxes.box;
 
-        &.enabled_b97e9a {
+        &.enabled_f4f0eb {
             @include boxes.clickable;
         }
 
-        &:is(.votedStyles_b5cb3c, [aria-checked="true"]) {
+        &:is(.votedStyles_a1443c, [aria-checked="true"]) {
             @include boxes.inset;
         }
 
         // Inner
-        .answerInner_cf2c85.currentlyVoting_cf2c85.selected_cf2c85 {
+        .answerInner__4c520.currentlyVoting__4c520.selected__4c520 {
             outline: none;
         }
     }

--- a/scss/main/_publicservers.scss
+++ b/scss/main/_publicservers.scss
@@ -4,7 +4,7 @@
 // Public servers and student hubs
 
 // Sidebar
-.sidebar_a4d4d9 > .thin_eed6a8 {
+.sidebar_c48ade > .thin__99f8c {
     margin-left: 28px;
 
     .discoverHeader_b992d4 {
@@ -31,7 +31,7 @@
 }
 
 // Main page
-.appMount_ea7e65 .pageWrapper_a3a4ce {
+.appMount__51fd7 .pageWrapper_a3a4ce {
     background: $grey;
 
     .scroller_a3a4ce {
@@ -67,7 +67,7 @@
         }
     }
 
-    .card_eb1ca6 {
+    .card_e90879 {
         @include boxes.clickable;
 
         &:is(:focus, :hover) {
@@ -160,14 +160,14 @@
         }
     }
 
-    .pageControl_b48941 {
+    .pageControl_c15210 {
         @include boxes.inset;
 
-        .roundButton_b48941 {
+        .roundButton_c15210 {
             @include boxes.clickable;
             margin: 0;
 
-            &.activeButton_b48941 {
+            &.activeButton_c15210 {
                 @include boxes.inset;
                 background: unset;
                 color: $black;
@@ -177,14 +177,14 @@
 }
 
 // Student hubs / custom guild directory
-.pageContainer_a9a262 {
+.pageContainer__09fde {
     @include boxes.inset;
 
-    .card_f18d6c {
+    .card__0c0bf {
         @include boxes.box;
     }
 }
-.scroller_c43953:has(.itemInner__2abad) {
+.scroller__629e4:has(.itemInner__2abad) {
     min-height: 200px;
 
     .itemInner__2abad {

--- a/scss/main/_searchresults.scss
+++ b/scss/main/_searchresults.scss
@@ -2,27 +2,27 @@
 @use "../top/boxes" as boxes;
 
 // Search results
-.searchResultsWrap_c2b47d {
+.searchResultsWrap_a9e706 {
     @include boxes.inset;
     margin: 0 2px 2px;
 
-    .searchHeader_b7c924 {
+    .searchHeader_f3b986 {
         background: transparent;
         padding: 8px 28px 0 16px;
         height: 28px;
 
         // Tabs
-        .searchHeaderTabList_b7c924 {
+        .searchHeaderTabList_f3b986 {
             gap: 0;
 
             // Tab
-            .item_a0 {
+            .item_b3f026 {
                 @include boxes.tab;
             }
         }
     }
 
-    .scroller_c2b47d {
+    .scroller_a9e706 {
         @include boxes.box($position: static);
         margin: 0 8px 8px;
 
@@ -31,13 +31,13 @@
         }
 
         // Result
-        .searchResult_ddc613 {
+        .searchResult__02a39 {
             background: $bg;
             @include boxes.inset;
         }
 
         // Jump button
-        .button_ddc613 {
+        .button__02a39 {
             @include boxes.clickable;
         }
 
@@ -46,7 +46,7 @@
         }
 
         // Navigation
-        .container_de9d09 {
+        .container__3f123 {
             position: absolute;
             top: 29px;
             left: 9px;
@@ -55,13 +55,13 @@
             z-index: 1;
             border-bottom: 1px solid $black;
 
-            .pageControlContainer_b48941 {
+            .pageControlContainer_c15210 {
                 margin-top: 0;
             }
 
-            .pageControl_b48941 {
+            .pageControl_c15210 {
                 // Buttons
-                .pageButton_b48941 {
+                .pageButton_c15210 {
                     min-height: unset;
                     margin: 0;
 

--- a/scss/main/_serverguide.scss
+++ b/scss/main/_serverguide.scss
@@ -1,24 +1,24 @@
 @use "../top/vars" as *;
 @use "../top/boxes" as boxes;
 
-.homeContainer_e85cee {
+.homeContainer__7449f {
     @include boxes.scroller;
     padding: 32px 16px;
     background: $bg;
 }
 
 // Server name
-.headerName_d32e26 {
+.headerName__553a5 {
     color: $text;
 }
 
 // Main section headers
-.mainContent_e85cee h2 {
+.mainContent__7449f h2 {
     color: $text !important;
 }
 
 // Main section item
-.row_b53f4f {
+.row_d13feb {
     @include boxes.clickable;
     &:hover {
         background: $grey;
@@ -26,6 +26,6 @@
 }
 
 // Sidebar card
-.sidebarCardWrapper_e85cee {
+.sidebarCardWrapper__7449f {
     @include boxes.box;
 }

--- a/scss/main/_serversubscriptions.scss
+++ b/scss/main/_serversubscriptions.scss
@@ -1,24 +1,24 @@
 @use "../top/vars" as *;
 @use "../top/boxes" as boxes;
 
-.container_fca846 {
+.container__808a1 {
     background: $grey;
 
-    .scroller_fca846 {
+    .scroller__808a1 {
         @include boxes.scroller;
         background: $bg;
     }
 }
 
-.ctaTitle_d575b2,
-.ctaTitle_d575b2 strong {
+.ctaTitle__7e486,
+.ctaTitle__7e486 strong {
     color: $text;
 }
 
-.ctaSubtitle_d575b2 {
+.ctaSubtitle__7e486 {
     color: $text !important;
 }
 
-.roleMessagePreview_ecba8f {
+.roleMessagePreview__3efc4 {
     background: $bg;
 }

--- a/scss/main/_taskbar.scss
+++ b/scss/main/_taskbar.scss
@@ -11,7 +11,7 @@
 }
 
 // Taskbar
-.wrapper_fea3ef .scroller_fea3ef {
+.wrapper_ef3116 .scroller_ef3116 {
     @include boxes.box;
     background: var(--background-secondary);
     border-color: $white $white $black $black;
@@ -27,32 +27,32 @@
 }
 
 // Folder/server icon
-.listItem_c96c45:not(:has(.guildSeparator_d0c57e)) {
+.listItem__650eb:not(:has(.guildSeparator__252b6)) {
     @include boxes.clickable;
 }
 
 // Closed folder icon
 @include fi.folderIcon;
-.expandedFolderBackground_bc7085.collapsed_bc7085 + .listItem_c96c45 {
-    .guildIcon_bc7085 {
+.expandedFolderBackground__48112.collapsed__48112 + .listItem__650eb {
+    .guildIcon__48112 {
         display: none;
     }
 }
 
 // Opened folder background strip
-.expandedFolderBackground_bc7085:not(.collapsed_bc7085) {
+.expandedFolderBackground__48112:not(.collapsed__48112) {
     background: transparent;
 }
 
-.folder_bc7085 {
-    .icon_f11207,
+.folder__48112 {
+    .icon_f34534,
     svg {
         display: none;
     }
 }
 
 // Control panel
-.panels_a4d4d9 {
+.panels_c48ade {
     @include boxes.box;
     position: fixed;
     bottom: 0;
@@ -67,17 +67,17 @@
 }
 
 // Flip order
-.container_b2ca13 {
+.container__37e49 {
     height: calc(var(--server-container) - 2px);
     flex-direction: row-reverse;
     gap: 6px;
 }
 
 // Controls
-.button_f67531 {
+.button__67645 {
     @include boxes.clickable;
 
-    &.enabled_f67531:hover,
+    &.enabled__67645:hover,
     &:active {
         background: inherit;
         color: inherit;
@@ -85,7 +85,7 @@
 }
 
 // User
-.avatarWrapper_b2ca13 {
+.avatarWrapper__37e49 {
     @include boxes.inset;
     margin-right: 0;
 }

--- a/scss/main/_threads.scss
+++ b/scss/main/_threads.scss
@@ -2,7 +2,7 @@
 @use "../top/boxes" as boxes;
 
 // Main chat with thread open
-.chat_a7d72e:not(.container_f1fd9c > .chat_a7d72e):is(.threadSidebarOpen_a7d72e, .threadSidebarOpen_a7d72e) {
+.chat_f75fb0:not(.container__0b563 > .chat_f75fb0):is(.threadSidebarOpen_f75fb0, .threadSidebarOpen_f75fb0) {
     border-right: 0;
 
     &::before {
@@ -10,20 +10,20 @@
     }
 
     // Message needs no indent as member list cannot be visible at once.
-    .chatContent_a7d72e .message_d5deea {
+    .chatContent_f75fb0 .message__5126c {
         margin-right: 0 !important;
     }
 
     // Neither does autocompleter
-    .autocomplete_f23da8 {
+    .autocomplete__13533 {
         width: auto !important;
     }
 }
 
 // Threads not video chat
-.content_a4d4d9 > {
+.content_c48ade > {
     // Main chat / thread separator
-    .resizeHandle_d1c246 {
+    .resizeHandle__01ae2 {
         @include boxes.box;
         background: $grey;
         position: relative;
@@ -40,7 +40,7 @@
     }
 
     // Thread panel
-    .container_d1c246 {
+    .container__01ae2 {
         @include boxes.box;
         margin: $window-top 0 $window-bottom 0;
         right: $window-right;
@@ -53,18 +53,18 @@
     }
 
     // Floating thread panel for narrow screens
-    .chatLayerWrapper_d1c246 {
+    .chatLayerWrapper__01ae2 {
         top: $title-height + $window-top;
         right: $window-right;
         bottom: $window-bottom + 2px;
         height: auto;
 
-        .chatTarget_d1c246 {
+        .chatTarget__01ae2 {
             display: none;
         }
     }
 }
 
-.layerContainer_cd0de5:has(.chatLayerWrapper_d1c246) {
+.layerContainer_da8173:has(.chatLayerWrapper__01ae2) {
     z-index: 0;
 }

--- a/scss/main/_vc.scss
+++ b/scss/main/_vc.scss
@@ -2,59 +2,59 @@
 @use "../top/boxes" as boxes;
 
 // Voice chat
-.wrapper_d880dc {
+.wrapper_cb9592 {
     margin-top: 28px;
     z-index: 0;
 
-    &.minimum_d880dc {
+    &.minimum_cb9592 {
         height: 204px;
     }
 
-    .callContainer_d880dc {
+    .callContainer_cb9592 {
         background: $bg;
     }
 
-    &:is(.chatSidebarOpen_d880dc, .fullScreen_d880dc, .noChat_d880dc) {
+    &:is(.sidebarOpen_cb9592, .fullScreen_cb9592, .noChat_cb9592) {
         height: calc(100% - 28px);
     }
 
-    .voiceCallWrapper_bae578 {
+    .voiceCallWrapper_a21736 {
         position: relative;
         padding: 0;
         top: -12px;
 
         // Avatars in DM VC
-        .participant_ea9cce {
+        .participant_c8dbe9 {
             margin: 0 4px;
         }
 
-        .callAvatarMask_a5cd29 {
+        .callAvatarMask_f910d0 {
             @include boxes.inset;
         }
     }
 
-    .videoControls_dd069c {
+    .videoControls_bfe55a {
         padding: 0;
 
         // No tint
-        .gradientContainer_dd069c {
+        .gradientContainer_bfe55a {
             background: none;
         }
 
-        .controlSection_dd069c {
+        .controlSection_bfe55a {
             background: $grey;
             border: 0 solid $darkgrey;
 
             // Top bar
-            &.topControls_dd069c:not(.minimum_d880dc .topControls_dd069c) {
+            &.topControls_bfe55a:not(.minimum_cb9592 .topControls_bfe55a) {
                 border-bottom-width: 1px;
             }
 
-            .headerWrapper_d880dc {
+            .headerWrapper_cb9592 {
                 margin: 0;
 
                 // Region selector
-                & + .horizontal_bba380 {
+                & + .horizontal__7c0ba {
                     margin-right: 8px;
                     position: absolute;
                     right: 0;
@@ -68,87 +68,87 @@
                 }
             }
 
-            .toolbar_e44302 button {
+            .toolbar__9293f button {
                 @include boxes.clickable;
                 margin: 0;
                 height: 32px;
                 width: 32px;
-                .controlIcon_ef18ee {
+                .controlIcon_f1ceac {
                     color: $black;
                 }
             }
 
             // Bottom bar
-            &.bottomControls_dd069c {
+            &.bottomControls_bfe55a {
                 padding: 8px;
                 width: auto;
 
-                &:not(.minimum_d880dc .bottomControls_dd069c) {
+                &:not(.minimum_cb9592 .bottomControls_bfe55a) {
                     border-top-width: 1px;
                 }
 
                 // Centre controls
-                .wrapper_b6e2f9 {
-                    .controlButton_b6e2f9 {
+                .wrapper__1405b {
+                    .controlButton__1405b {
                         @include boxes.clickable;
                         margin: 0;
 
                         // Active unmute button
-                        &:has(.white_ef18ee),
-                        &.white_ef18ee {
+                        &:has(.white_f1ceac),
+                        &.white_f1ceac {
                             @include boxes.inset;
                         }
                     }
 
                     // Set button colours
-                    .colorable_ef18ee {
+                    .colorable_f1ceac {
                         // Most buttons
-                        &.primaryDark_ef18ee {
+                        &.primaryDark_f1ceac {
                             background: unset;
                             color: $black;
 
-                            .centerIcon_ef18ee {
+                            .centerIcon_f1ceac {
                                 color: $black;
                             }
                         }
 
                         // Leave call button
-                        &:is(.red_ef18ee, .red_ef18ee:hover) {
+                        &:is(.red_f1ceac, .red_f1ceac:hover) {
                             background: $red;
                         }
 
                         // Active buttons
-                        &.white_ef18ee {
+                        &.white_f1ceac {
                             background: unset;
                         }
                     }
 
                     // Dropdown menu button in button
-                    .contextMenuNub_ef18ee {
+                    .contextMenuNub_f1ceac {
                         @include boxes.clickable($position: absolute);
                         left: 0;
                         width: auto;
                         height: 12px;
                         padding: 0;
 
-                        &.active_ef18ee {
+                        &.active_f1ceac {
                             @include boxes.inset($position: absolute);
                         }
                     }
                 }
 
                 // Other buttons
-                button:not(.wrapper_b6e2f9 button) {
+                button:not(.wrapper__1405b button) {
                     @include boxes.clickable;
                     margin: 0;
                     height: 32px;
                     width: 32px;
 
-                    .controlIcon_ef18ee {
+                    .controlIcon_f1ceac {
                         color: $black;
                     }
 
-                    &.buttonColor_d4af21 {
+                    &.buttonColor__7b3e8 {
                         padding: 0;
                         background: unset;
                         color: $black;
@@ -164,7 +164,7 @@
             width: 32px;
             top: 8px;
 
-            .controlIcon_ef18ee {
+            .controlIcon_f1ceac {
                 color: $black;
             }
         }

--- a/scss/main/_windowbar.scss
+++ b/scss/main/_windowbar.scss
@@ -3,7 +3,7 @@
 
 // Top bar
 
-.titleBar_a934d8 {
+.titleBar__421ed {
     margin: unset;
     @include boxes.winBar($text: "Discord", $bgColor: $darkblue);
     position: absolute;
@@ -13,7 +13,7 @@
     z-index: 102;
 
     // Discord logo
-    .wordmarkWindows_a934d8 {
+    .wordmarkWindows__421ed {
         padding: 0;
         margin: 2px 0 0 2px;
 
@@ -31,7 +31,7 @@
     }
 
     // Buttons
-    .winButton_a934d8 {
+    .winButton__421ed {
         @include boxes.clickable;
         background: $grey;
         height: 16px;
@@ -39,14 +39,14 @@
         width: 20px;
         color: $black;
 
-        &.winButtonClose_a934d8 {
+        &.winButtonClose__421ed {
             margin-left: 2px;
         }
     }
 }
 
 // On Linux
-.platform-linux .appMount_ea7e65 {
+.platform-linux .appMount__51fd7 {
     @include boxes.winBar($isPseudo: true, $bgColor: $darkblue, $text: "Discord");
 
     &::after {

--- a/scss/mod/_BetterDiscord.scss
+++ b/scss/mod/_BetterDiscord.scss
@@ -48,7 +48,7 @@
     }
 }
 
-.bd-addon-error-details .detailsIcon_d5408a {
+.bd-addon-error-details .detailsIcon__4a3a5 {
     color: var(--header-secondary);
 }
 
@@ -56,7 +56,7 @@
     display: none;
 }
 
-.bd-addon-error-stack .scrollbarGhostHairline_c858ce {
+.bd-addon-error-stack .scrollbarGhostHairline__506b3 {
     @include boxes.inset;
     background: $white;
     max-height: 200px;
@@ -233,7 +233,7 @@
 
 // Maybe not BD, but goes here for now.
 // Update modal text
-:is(.theme-dark, .theme-light) .markdown_d7f12d {
+:is(.theme-dark, .theme-light) .markdown_d285a6 {
     color: $black;
 }
 

--- a/scss/mod/_Vencord.scss
+++ b/scss/mod/_Vencord.scss
@@ -4,7 +4,7 @@
 // Vencord
 
 // Theme links
-.inputWrapper_f8bc55 .vc-settings-theme-links.input_f8bc55 {
+.inputWrapper__0f084 .vc-settings-theme-links.input__0f084 {
     max-height: unset;
     height: 10rem;
     color: $text !important;
@@ -22,7 +22,7 @@
         margin-bottom: 0;
     }
 
-    .icons_f6639d {
+    .icons__3f413 {
         width: 20px;
         height: 20px;
         color: $black;
@@ -42,10 +42,10 @@
     .vc-addon-header > div:last-child {
         @include boxes.box;
 
-        .container_cebd1c {
+        .container__87bf1 {
             background: $darkgrey !important;
 
-            .slider_cebd1c {
+            .slider__87bf1 {
                 rect {
                     fill: $lightgrey;
                 }
@@ -54,10 +54,10 @@
                 }
             }
 
-            &.checked_cebd1c {
+            &.checked__87bf1 {
                 background: $green !important;
 
-                .slider_cebd1c {
+                .slider__87bf1 {
                     svg path {
                         fill: $green;
                     }
@@ -87,7 +87,7 @@
 }
 
 // Donate link
-.vc-settings-donate .lookLink_dd4f85.colorTransparent_dd4f85 {
+.vc-settings-donate .lookLink__201d5.colorTransparent__201d5 {
     color: $black;
 }
 

--- a/scss/overlay/_layer.scss
+++ b/scss/overlay/_layer.scss
@@ -1,25 +1,25 @@
 @use "../top/vars" as *;
 @use "../top/boxes" as boxes;
 
-.baseLayer_d4b6c5.stop-animations {
+.baseLayer__960e4.stop-animations {
     opacity: 1 !important;
     transform: scale(1) !important;
 
-    .container_a4d4d9 {
+    .container_c48ade {
         filter: grayscale(0.8) brightness(0.5);
         backdrop-filter: brightness(1);
     }
 }
 
-.layers_d4b6c5 > .layer_d4b6c5 .animating_d4b6c5 {
+.layers__960e4 > .layer__960e4 .animating__960e4 {
     transform: none !important;
 }
 
-.layer_d4b6c5 {
+.layer__960e4 {
     background: transparent;
 }
 
-.pictureInPictureWindow_d0596b {
+.pictureInPictureWindow__6341f {
     overflow: visible;
     border-radius: 0;
 

--- a/scss/overlay/_tooltips.scss
+++ b/scss/overlay/_tooltips.scss
@@ -1,12 +1,12 @@
 @use "../top/vars" as *;
 
-.tooltip_b6c360 {
+.tooltip__382e7 {
     border: 1px solid $black;
-    .tooltipPointer_b6c360 {
+    .tooltipPointer__382e7 {
         display: none;
     }
 }
 
-.reactionTooltip_fba897 {
+.reactionTooltip_b49891 {
     border: 1px solid $black;
 }

--- a/scss/overlay/modals/_activities.scss
+++ b/scss/overlay/modals/_activities.scss
@@ -2,17 +2,17 @@
 @use "../../top/boxes" as boxes;
 
 // Activities
-.scrollSection_f09e45 {
+.scrollSection__35455 {
     padding: 0 8px;
 }
 
-.shelf_f09e45 {
+.shelf__35455 {
     gap: 8px;
 
-    .activityItem_d46b95 {
+    .activityItem__18da2 {
         @include boxes.clickable;
 
-        .activityTag_d46b95 {
+        .activityTag__18da2 {
             @include boxes.box;
         }
     }

--- a/scss/overlay/modals/_avatardecoration.scss
+++ b/scss/overlay/modals/_avatardecoration.scss
@@ -1,17 +1,17 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.modalContent_d9c03f:has(.decorationGridItem_b35b54) {
-    .list_b35b54 {
+.modalContent_ced2f2:has(.decorationGridItem_dfa67d) {
+    .list_dfa67d {
         @include boxes.scroller;
         left: 0;
 
-        .content_eed6a8 > div {
+        .content__99f8c > div {
             left: 0 !important;
         }
     }
 
-    .decorationGridItem_b35b54 {
+    .decorationGridItem_dfa67d {
         @include boxes.clickable;
 
         &.selected-IxbpGM {
@@ -20,10 +20,10 @@
         }
     }
 
-    .wrapper_c51b4e {
+    .wrapper__44b0c {
         @include boxes.box;
 
-        .avatarDecoration_c51b4e {
+        .avatarDecoration__44b0c {
             z-index: 1;
         }
     }

--- a/scss/overlay/modals/_carousel.scss
+++ b/scss/overlay/modals/_carousel.scss
@@ -3,8 +3,8 @@
 
 // Multi image carousel
 
-.modalCarouselWrapper_b586d2 {
-    .arrowContainer_b65c0b {
+.modalCarouselWrapper_f74404 {
+    .arrowContainer__31873 {
         @include boxes.clickable($position: absolute);
         background: $grey;
     }

--- a/scss/overlay/modals/_changeavatar.scss
+++ b/scss/overlay/modals/_changeavatar.scss
@@ -1,8 +1,8 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.imagePickerContainer_f2f431 {
-    .optionBox_f2f431 {
+.imagePickerContainer_edf440 {
+    .optionBox_edf440 {
         @include boxes.clickable;
     }
 }

--- a/scss/overlay/modals/_customstatus.scss
+++ b/scss/overlay/modals/_customstatus.scss
@@ -3,17 +3,17 @@
 
 // Set a custom status
 
-.inputContainer_d5bea8 {
-    .emojiButtonContainer_d5bea8,
-    .clearButton_d5bea8 {
+.inputContainer__9b8f6 {
+    .emojiButtonContainer__9b8f6,
+    .clearButton__9b8f6 {
         z-index: 1;
     }
 
-    .clearIcon_d5bea8 {
+    .clearIcon__9b8f6 {
         color: $text;
     }
 
-    .inputWrapper_f8bc55 .input_d5bea8 {
+    .inputWrapper__0f084 .input__9b8f6 {
         padding-left: 42px;
         padding-right: 36px;
         height: 40px;

--- a/scss/overlay/modals/_editaccount.scss
+++ b/scss/overlay/modals/_editaccount.scss
@@ -2,24 +2,24 @@
 @use "../../top/boxes" as boxes;
 
 // Edit / add phone number
-.phoneVerificationModal_a4eb9e {
-    .animationContainer_a4eb9e {
+.phoneVerificationModal_db41ea {
+    .animationContainer_db41ea {
         z-index: 1;
     }
 
-    .phoneField_d4eb58 {
+    .phoneField_a0c54f {
         @include boxes.inset;
 
-        .plusSign_d4eb58,
-        .countryCode_d4eb58 {
+        .plusSign_a0c54f,
+        .countryCode_a0c54f {
             color: $black;
         }
 
-        .phoneFieldExpand_d4eb58 {
+        .phoneFieldExpand_a0c54f {
             stroke: $black;
         }
 
-        .inputField_d4eb58 {
+        .inputField_a0c54f {
             color: $text;
         }
     }
@@ -31,10 +31,10 @@
 }
 
 // Edit username
-.multiInput_aefbba {
+.multiInput_b404ff {
     height: 24px;
 
-    .inputPrefix_f8bc55 {
+    .inputPrefix__0f084 {
         display: none;
     }
 

--- a/scss/overlay/modals/_feedback.scss
+++ b/scss/overlay/modals/_feedback.scss
@@ -1,18 +1,18 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.ratingsSelector_b58b14 {
+.ratingsSelector__6c12c {
     width: auto;
 
-    .horizontal_bba380 > & {
+    .horizontal__7c0ba > & {
         margin-left: 0;
     }
 
-    .emoji_b58b14 {
+    .emoji__6c12c {
         @include boxes.clickable;
     }
 }
 
-.horizontal_bba380:has(.ratingsSelector_b58b14) + .content_f9a4c9 {
+.horizontal__7c0ba:has(.ratingsSelector__6c12c) + .content__49fc1 {
     display: none;
 }

--- a/scss/overlay/modals/_index.scss
+++ b/scss/overlay/modals/_index.scss
@@ -18,28 +18,28 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.root_f9a4c9:not(.carouselModal_d2b9a1) {
+.root__49fc1:not(.carouselModal_d2b9a1) {
     @include boxes.box;
 
     // Header and footer
     .modalHeader-3X0A4K,
-    .footer_f9a4c9 {
+    .footer__49fc1 {
         @include boxes.box;
     }
 }
 
-.artContainer_ffaecb {
+.artContainer__3ec70 {
     display: none;
 }
 
-.content_f9a4c9 {
+.content__49fc1 {
     @include boxes.scroller;
     padding-top: 18px;
     margin-bottom: 0;
 }
 
 // Changelog
-.layerContainer_cd0de5 {
+.layerContainer_da8173 {
     .content_dc3a33 {
         :is(ol, p, ul li) {
             color: $black;
@@ -55,7 +55,7 @@
         }
     }
 
-    .improved_f017d0 {
+    .improved__1689b {
         color: $darkblue;
 
         &::after {
@@ -63,7 +63,7 @@
         }
     }
 
-    .fixed_f017d0 {
+    .fixed__1689b {
         color: $red;
 
         &::after {

--- a/scss/overlay/modals/_notifsettings.scss
+++ b/scss/overlay/modals/_notifsettings.scss
@@ -2,23 +2,23 @@
 @use "../../top/boxes" as boxes;
 
 // Notification settings
-.root_f9a4c9 {
-    .override_cacc4c,
-    .overrideHighlight_cacc4c,
-    .guildName_cacc4c,
-    .channelName_cacc4c {
+.root__49fc1 {
+    .override_db81c6,
+    .overrideHighlight_db81c6,
+    .guildName_db81c6,
+    .channelName_db81c6 {
         color: $black;
     }
 
-    .override_cacc4c {
+    .override_db81c6 {
         padding: 8px;
 
-        .checkboxGroup_cacc4c {
+        .checkboxGroup_db81c6 {
             width: 300px;
             margin-right: -8px;
         }
 
-        .removeOverride_cacc4c {
+        .removeOverride_db81c6 {
             z-index: 2;
             @include boxes.clickable($position: absolute);
             background-color: $grey;

--- a/scss/overlay/modals/_quickswitcher.scss
+++ b/scss/overlay/modals/_quickswitcher.scss
@@ -2,43 +2,43 @@
 @use "../../top/boxes" as boxes;
 @use "../../top/msgPill" as msg;
 
-.root_f9a4c9:has(.quickswitcher_f4e139) {
+.root__49fc1:has(.quickswitcher_ac6cb0) {
     height: 380px;
 }
 
-.quickswitcher_f4e139 {
+.quickswitcher_ac6cb0 {
     min-height: 380px;
 
     // Search
-    .input_f4e139 {
+    .input_ac6cb0 {
         @include boxes.inset;
         color: $text;
     }
 
     // Results
-    .scroller_f4e139 {
+    .scroller_ac6cb0 {
         @include boxes.scroller;
 
-        .content_eed6a8 {
+        .content__99f8c {
             border-right: 1px solid $darkgrey;
         }
 
         // Entry
-        .result_f14193 {
+        .result__71961 {
             &:hover,
             &[aria-selected="true"] {
                 background: $darkblue;
 
-                .contentDefault_f14193,
-                .icon_f14193,
-                .misc_f14193,
-                .contentUnread_f14193 {
+                .contentDefault__71961,
+                .icon__71961,
+                .misc__71961,
+                .contentUnread__71961 {
                     color: $white;
                 }
             }
 
             // Unread pill
-            .contentUnread_f14193 {
+            .contentUnread__71961 {
                 @include msg.unreadPill($size: 8px);
             }
         }

--- a/scss/overlay/modals/_report.scss
+++ b/scss/overlay/modals/_report.scss
@@ -3,22 +3,22 @@
 
 // Report message
 
-.header_e89716 {
+.header__527b1 {
     padding: 16px;
 }
 
-.messagePreviewContainer_b06e1c {
+.messagePreviewContainer_f96002 {
     background: $bg;
     @include boxes.inset;
 }
 
-.childButton_f45bfc {
+.childButton__3ed08 {
     @include boxes.clickable;
     margin-bottom: 0;
     min-height: auto;
 }
 
-.checkboxRow_a7652f {
+.checkboxRow_d1f0f0 {
     @include boxes.clickable;
     padding: 4px;
 

--- a/scss/overlay/modals/_screenshare.scss
+++ b/scss/overlay/modals/_screenshare.scss
@@ -9,12 +9,12 @@
 }
 
 // Tabs
-.tabItem_a18ec1 {
+.tabItem__9e06a {
     @include boxes.tab;
     margin-right: 0;
     color: $black;
 
-    &.tabItemSelected_a18ec1 {
+    &.tabItemSelected__9e06a {
         border-bottom: unset;
         color: $black;
         text-decoration: underline;
@@ -22,16 +22,16 @@
 }
 
 // Screens
-.sourceScroller_d7ec26 {
+.sourceScroller_a2de16 {
     @include boxes.scroller;
 }
 
-.sourceContainer_d7ec26 {
+.sourceContainer_a2de16 {
     gap: 8px;
 }
 
 // Screen
-.tile_d7ec26 {
+.tile_a2de16 {
     @include boxes.clickable;
     padding: 8px 0;
     flex: 0 1 calc(50% - 4px) !important;
@@ -47,22 +47,22 @@
 }
 
 // Stream quality
-.qualitySettingsContainer_a78967 {
+.qualitySettingsContainer_c6d3dc {
     @include boxes.inset;
 
-    .selectorButton_a78967 {
+    .selectorButton_c6d3dc {
         @include boxes.clickable;
 
         &:not(.selectorButtonPremiumRequired__9df5b):hover {
             background: $grey;
 
-            .selectorText_a78967 {
+            .selectorText_c6d3dc {
                 color: $black;
             }
         }
     }
 
-    .selectorButtonSelected_a78967 {
+    .selectorButtonSelected_c6d3dc {
         @include boxes.inset;
         background: $grey;
         .selectorTextSelected__147ec {

--- a/scss/overlay/modals/_sendinvite.scss
+++ b/scss/overlay/modals/_sendinvite.scss
@@ -1,7 +1,7 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.searchBar_cedfaf {
+.searchBar__67dba {
     @include boxes.inset;
     background: $bg;
     color: $text;
@@ -16,30 +16,30 @@
     }
 }
 
-.scroller_cedfaf {
+.scroller__67dba {
     @include boxes.inset;
     padding: 0;
 
-    .inviteRow_cedfaf {
-        .inviteRowName_cedfaf {
+    .inviteRow__67dba {
+        .inviteRowName__67dba {
             color: $black;
         }
 
         &:hover {
             background: $darkblue;
 
-            .inviteRowName_cedfaf,
-            .contents_dd4f85 {
+            .inviteRowName__67dba,
+            .contents__201d5 {
                 color: $white;
             }
         }
     }
 }
 
-.layerContainer_cd0de5 .footer_cedfaf {
+.layerContainer_da8173 .footer__67dba {
     background: $grey;
 
-    .input_f8bc55 {
+    .input__0f084 {
         height: 32px;
     }
 
@@ -47,7 +47,7 @@
         margin-right: 0;
     }
 
-    .footerText_cedfaf {
+    .footerText__67dba {
         color: $black;
     }
 

--- a/scss/overlay/modals/_userprofile.scss
+++ b/scss/overlay/modals/_userprofile.scss
@@ -5,7 +5,7 @@
     // Badges
     .badgeList_ec3b75 {
         gap: 0;
-        .anchor_af404b {
+        .anchor_edefb8 {
             @include boxes.clickable;
         }
     }
@@ -25,10 +25,10 @@
             height: auto;
             padding: 2px 8px;
 
-            &.themed_a0 {
+            &.themed_b3f026 {
                 color: var(--text-normal);
 
-                &:is(.selected_a0, :active) {
+                &:is(.selected_b3f026, :active) {
                     background: unset;
                     font-weight: bold;
                 }
@@ -37,7 +37,7 @@
     }
 
     // Info
-    .scrollerBase_eed6a8 {
+    .scrollerBase__99f8c {
         @include boxes.box;
 
         &::before {
@@ -49,26 +49,26 @@
         }
 
         // Connected accounts
-        .connectedAccounts_f3eb60 {
+        .connectedAccounts_e6abe8 {
             display: block;
             width: 100%;
 
-            .connectedAccountsColumn_f3eb60 {
+            .connectedAccountsColumn_e6abe8 {
                 display: inline;
                 margin-left: 0;
 
-                .connectedAccountContainer_f3eb60 {
+                .connectedAccountContainer_e6abe8 {
                     @include boxes.inset;
                     display: inline-block;
                     width: calc(460px / 3);
                     margin: 6px 6px 0 0;
 
                     // Open account in browser
-                    &:has(.anchor_af404b) {
+                    &:has(.anchor_edefb8) {
                         @include boxes.clickable;
                     }
 
-                    .anchor_af404b {
+                    .anchor_edefb8 {
                         position: absolute;
                         inset: 0;
 
@@ -78,17 +78,17 @@
                     }
 
                     // Hide detailed info until hover
-                    &.connectedAccountContainerWithMetadata_f3eb60 {
+                    &.connectedAccountContainerWithMetadata_e6abe8 {
                         padding: 12px 8px;
 
-                        .connectedAccountName_f3eb60 + .text-xs-normal_ccc5fb,
-                        .connectedAccountChildren_f3eb60 {
+                        .connectedAccountName_e6abe8 + .text-xs-normal_ccc5fb,
+                        .connectedAccountChildren_e6abe8 {
                             display: none;
                         }
 
                         &:hover {
-                            .connectedAccountName_f3eb60 + .text-xs-normal_ccc5fb,
-                            .connectedAccountChildren_f3eb60 {
+                            .connectedAccountName_e6abe8 + .text-xs-normal_ccc5fb,
+                            .connectedAccountChildren_e6abe8 {
                                 display: block;
                                 z-index: 1;
                                 padding: 8px;
@@ -96,14 +96,14 @@
                             }
 
                             // Joined date
-                            .connectedAccountName_f3eb60 + .text-xs-normal_ccc5fb {
+                            .connectedAccountName_e6abe8 + .text-xs-normal_ccc5fb {
                                 position: absolute;
                                 pointer-events: none;
                                 inset: 1px 1px 1px 32px;
                             }
 
                             // Detailed info
-                            &:hover .connectedAccountChildren_f3eb60 {
+                            &:hover .connectedAccountChildren_e6abe8 {
                                 @include boxes.box($position: absolute);
                                 bottom: 50px;
                                 left: -33px;
@@ -115,7 +115,7 @@
         }
 
         // Mutual servers
-        .listRow_e4be58 {
+        .listRow__9d78f {
             margin: 0;
 
             &:hover {

--- a/scss/overlay/modals/_videotest.scss
+++ b/scss/overlay/modals/_videotest.scss
@@ -3,17 +3,17 @@
 
 // Preview camera
 
-.backgroundOptionsSmall_ad7d79 {
+.backgroundOptionsSmall__53965 {
     gap: 8px;
 }
 
-.backgroundOptionRing_ad7d79 {
+.backgroundOptionRing__53965 {
     border-color: $blue;
 }
 
-.backgroundOption_ad7d79:hover:not(.backgroundOption_ad7d79.backgroundOptionDisabled_ad7d79):not(.backgroundOptionSelected_ad7d79) {
+.backgroundOption__53965:hover:not(.backgroundOption__53965.backgroundOptionDisabled__53965):not(.backgroundOptionSelected__53965) {
     &,
-    .backgroundImageOption_ad7d79 {
+    .backgroundImageOption__53965 {
         transform: none !important;
     }
 }

--- a/scss/overlay/modals/_welcome.scss
+++ b/scss/overlay/modals/_welcome.scss
@@ -2,6 +2,6 @@
 @use "../../top/boxes" as boxes;
 
 // Welcome to server
-.optionContainer_e3f8c2 {
+.optionContainer__949ab {
     @include boxes.clickable;
 }

--- a/scss/overlay/modals/_whatsnew.scss
+++ b/scss/overlay/modals/_whatsnew.scss
@@ -2,10 +2,10 @@
 @use "../../top/boxes" as boxes;
 
 // Changelog
-.small_f9a4c9:has(.modal__4f3da) {
+.small__49fc1:has(.modal__4f3da) {
     width: 492px;
 
-    .flexChild_bba380 > * {
+    .flexChild__7c0ba > * {
         color: $black;
     }
 

--- a/scss/overlay/popovers/_createdm.scss
+++ b/scss/overlay/popovers/_createdm.scss
@@ -3,33 +3,33 @@
 
 // Create (group) DM
 
-.header_f9a4c9 {
-    .subtitle_e6af9c {
+.header__49fc1 {
+    .subtitle_cba592 {
         color: $black;
     }
 
-    .searchBarComponent_e6af9c {
+    .searchBarComponent_cba592 {
         @include boxes.inset;
         background: $bg;
 
-        .inner_effbe2 {
+        .inner_fea832 {
             overflow: hidden !important;
         }
 
-        .input_effbe2 {
+        .input_fea832 {
             color: $text;
         }
 
-        .tag_effbe2 {
+        .tag_fea832 {
             @include boxes.clickable;
         }
     }
 }
 
-.scroller_e6af9c {
+.scroller_cba592 {
     @include boxes.scroller;
 
-    .friendWrapper_ebf869 {
+    .friendWrapper_bbd192 {
         @include boxes.clickable;
         margin: 0;
 
@@ -37,12 +37,12 @@
             @include boxes.inset;
         }
 
-        .friendSelected_ebf869 {
+        .friendSelected_bbd192 {
             background: unset;
         }
     }
 }
 
-.footer_e6af9c {
+.footer_cba592 {
     padding: 8px;
 }

--- a/scss/overlay/popovers/_dropdown.scss
+++ b/scss/overlay/popovers/_dropdown.scss
@@ -2,11 +2,11 @@
 @use "../../top/boxes" as boxes;
 
 // Dropdowns
-.popout_f6639d {
+.popout__3f413 {
     @include boxes.inset;
     background: $bg;
 
-    .option_f6639d {
+    .option__3f413 {
         padding: 4px 8px;
         color: $text;
 
@@ -18,17 +18,17 @@
             opacity: 1;
         }
 
-        &[aria-selected="true"]:not(.option_f6639d.multi_f6639d) {
+        &[aria-selected="true"]:not(.option__3f413.multi__3f413) {
             background: $lightgrey;
         }
 
-        .content_f6639d {
+        .content__3f413 {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
         }
 
-        .selectedIcon_f6639d {
+        .selectedIcon__3f413 {
             color: $darkblue;
         }
     }

--- a/scss/overlay/popovers/_editor.scss
+++ b/scss/overlay/popovers/_editor.scss
@@ -2,13 +2,13 @@
 @use "../../top/boxes" as boxes;
 
 // Highlighted text editor
-.buttons_de3e42 {
+.buttons_bba883 {
     @include boxes.box;
     background: $grey;
 
-    .icon_de3e42,
-    .active__05fbc .icon_de3e42,
-    .hover_d0ebf2:hover .icon_de3e42 {
+    .icon_bba883,
+    .active__05fbc .icon_bba883,
+    .hover_d0ebf2:hover .icon_bba883 {
         color: $black;
     }
 
@@ -16,7 +16,7 @@
         @include boxes.inset;
     }
 
-    .divider_de3e42 {
+    .divider_bba883 {
         display: none;
     }
 }

--- a/scss/overlay/popovers/_emojiinfo.scss
+++ b/scss/overlay/popovers/_emojiinfo.scss
@@ -2,10 +2,10 @@
 @use "../../top/boxes" as boxes;
 
 // Emoji info
-.popoutContainer_cf58b5 {
+.popoutContainer__0f481 {
     @include boxes.box;
 
-    .guildSection_e58351 {
+    .guildSection_d5cd2d {
         @include boxes.box;
     }
 }

--- a/scss/overlay/popovers/_emotes.scss
+++ b/scss/overlay/popovers/_emotes.scss
@@ -1,7 +1,7 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.contentWrapper_af5dbb,
+.contentWrapper__08434,
 .contentWrapper_eab878 {
     @include boxes.box;
     // grid-row-gap: 0;
@@ -9,66 +9,66 @@
 
 // Gifs / Stickers / Emojis tabs
 // Reaction / Super Reaction tabs
-:is(.nav_af5dbb, .nav__2aafa) {
+:is(.nav__08434, .nav__2aafa) {
     border-bottom: 1px solid $darkgrey;
 }
-:is(.navItem_af5dbb, .navItem_bd587d) {
+:is(.navItem__08434, .navItem_bd587d) {
     @include boxes.tab;
     margin-right: 0;
     top: -2px;
 
-    & + .navItem_af5dbb {
+    & + .navItem__08434 {
         margin-left: 0;
     }
 
-    &:is(.navButtonActive_af5dbb, .navButtonActive_b003de) {
+    &:is(.navButtonActive__08434, .navButtonActive_b003de) {
         background: $grey;
         color: var(--interactive-active);
     }
 }
 
 // Search bar
-:is(.container_effbe2, .container__33507) {
+:is(.container_fea832, .container__33507) {
     @include boxes.inset;
     background: $bg;
     margin-right: 0;
 
-    .inner_effbe2 {
+    .inner_fea832 {
         padding-right: 1px !important;
         overflow: hidden !important;
     }
 
-    :is(.input_effbe2, .input__48d49) {
+    :is(.input_fea832, .input__48d49) {
         color: $text;
     }
 
     // Search button
-    :is(.iconLayout_effbe2, .iconLayout__67261) {
+    :is(.iconLayout_fea832, .iconLayout__67261) {
         @include boxes.clickable;
         background: $grey;
         cursor: pointer;
     }
 
-    &.disabled_effbe2 :is(.iconLayout_effbe2, .iconLayout__67261) {
+    &.disabled_fea832 :is(.iconLayout_fea832, .iconLayout__67261) {
         @include boxes.box;
     }
 }
 
 // Header
-:is(.emojiPickerHasTabWrapper_c6ee36 .header_c6ee36, .header_c6ee36, .header_d8cdac, .header_b56bbc) {
+:is(.emojiPickerHasTabWrapper_c0e32c .header_c0e32c, .header_c0e32c, .header__8ef02, .header_fed6d3) {
     padding: 0 8px 8px;
 
     // VC picker
-    &.emojiPickerHeader_bdea70 {
+    &.emojiPickerHeader__0800c {
         padding-top: 8px;
 
-        .tooltipContainer_b7d6f1 {
+        .tooltipContainer_df4aaf {
             @include boxes.clickable;
         }
     }
 
     // Back button
-    .backButton_b56bbc {
+    .backButton_fed6d3 {
         @include boxes.clickable;
         margin-right: 0;
         padding: 2px 4px;
@@ -76,11 +76,11 @@
     }
 
     // Skin tone selector
-    .diversitySelectorButton_cce80d {
+    .diversitySelectorButton_a45a2a {
         @include boxes.clickable;
         padding: 4px;
     }
-    .diversitySelectorOptions_cce80d {
+    .diversitySelectorOptions_a45a2a {
         @include boxes.box($position: absolute);
         right: 16px;
     }
@@ -92,7 +92,7 @@
 }
 
 // Emoji picker only panel, eg. in custom status modal
-.layer_cd0de5 #emoji-picker-tab-panel {
+.layer_da8173 #emoji-picker-tab-panel {
     @include boxes.box;
     background: $grey;
     padding-top: 8px;
@@ -103,18 +103,18 @@
     background: $grey;
 
     // Scroller
-    .container_af1167 {
+    .container_d02962 {
         background: $bg;
     }
 
     // Favourites
-    .categoryFadeBlurple_af1167 {
+    .categoryFadeBlurple_d02962 {
         background: $darkblue;
         opacity: 0.7;
     }
 
     // Gif / Category
-    .result_bad108 {
+    .result__2dc39 {
         background: $bg !important;
         @include boxes.clickable;
 
@@ -125,7 +125,7 @@
 }
 
 // Emoji / Sticker picker
-:is(.bodyWrapper_c6ee36, .listWrapper_d8cdac) {
+:is(.bodyWrapper_c0e32c, .listWrapper__8ef02) {
     background: $bg;
 
     // Super reactions ad
@@ -136,47 +136,47 @@
     }
 
     // No results search suggestion
-    .searchSuggestion_de4721 {
+    .searchSuggestion_e94b8c {
         @include boxes.clickable;
     }
 
     // Emojis list
-    .listItems_dcade6 {
+    .listItems_affa7e {
         left: 0 !important;
 
         // Category section
-        .categorySection_a3bc57 {
+        .categorySection_c656ac {
             margin-bottom: 0;
         }
 
         // Category header
-        :is(.header_a3bc57, .packHeader_de4721) {
+        :is(.header_c656ac, .packHeader_e94b8c) {
             @include boxes.box;
             z-index: 2;
 
-            .header_e06857 {
+            .header__14245 {
                 width: 100%;
                 height: 100%;
             }
 
-            .headerLabel_e06857 {
+            .headerLabel__14245 {
                 text-transform: none;
             }
         }
 
-        .emojiItem_fbfedd {
+        .emojiItem_fc7141 {
             @include boxes.clickable;
 
             &.emojiItemDisabled__843ea {
                 @include boxes.box;
             }
 
-            &.emojiItemSelected_fbfedd {
+            &.emojiItemSelected_fc7141 {
                 background: transparent;
             }
         }
 
-        .row_a708c4 {
+        .row_c6367b {
             $gap: 32px;
             column-gap: $gap !important;
             margin-left: $gap;
@@ -185,7 +185,7 @@
             & > div {
                 @include boxes.clickable;
 
-                .inspectedIndicator_a708c4 {
+                .inspectedIndicator_c6367b {
                     background: transparent;
                 }
             }
@@ -194,22 +194,22 @@
 }
 
 // Emoji info
-.inspector_c3120f {
+.inspector_aeaaeb {
     @include boxes.box;
 }
 
 // Servers list
-:is(.emojiPickerHasTabWrapper_c6ee36 .categoryList_c6ee36, .categoryList_c6ee36, .categoryList_a7a485) {
+:is(.emojiPickerHasTabWrapper_c0e32c .categoryList_c0e32c, .categoryList_c0e32c, .categoryList__3ad28) {
     @include boxes.box($position: absolute);
     top: 45px;
 
-    :is(.categoryItem_dfa278, .stickerCategory_a7a485) {
+    :is(.categoryItem_b9ee0c, .stickerCategory__3ad28) {
         @include boxes.clickable;
         margin-bottom: 0;
     }
 
     // Divider
-    :is(.guildCategorySeparator_dfa278, .guildCategorySeparator_a7a485) {
+    :is(.guildCategorySeparator_b9ee0c, .guildCategorySeparator__3ad28) {
         border: unset;
         margin: 4px;
     }

--- a/scss/overlay/popovers/_inbox.scss
+++ b/scss/overlay/popovers/_inbox.scss
@@ -2,26 +2,26 @@
 @use "../../top/boxes" as boxes;
 
 // Inbox
-.recentMentionsPopout_ddb5b4 {
+.recentMentionsPopout__95796 {
     @include boxes.box;
     max-height: calc(100vh - $window-top - 120px) !important;
 
     // Header
-    .header_f0cd33.expanded_f0cd33 {
+    .header_ab6641.expanded_f0cd33 {
         padding: 6px;
         padding-bottom: 0;
 
-        .inboxIcon_f0cd33,
+        .inboxIcon_ab6641,
         .base__5ed84 {
             color: $black;
             background: transparent !important;
         }
 
-        .topPill_a0 {
+        .topPill_b3f026 {
             position: relative;
             top: 17px;
 
-            .tab_f0cd33 {
+            .tab_ab6641 {
                 @include boxes.tab;
                 margin-right: 0;
 
@@ -33,7 +33,7 @@
     }
 
     // Messages
-    :is(.scroller_f1c3d9, .messagesPopout_ac90a2, .container_fe1358) {
+    :is(.scroller__2692d, .messagesPopout__45690, .container__0f711) {
         .tertiary_ad6d80 {
             @include boxes.clickable;
 
@@ -42,16 +42,16 @@
             }
         }
 
-        .markReadButton_d09ffd {
+        .markReadButton__427f0 {
             margin-left: 0;
         }
 
-        :is(.messageContainer_ddb5b4, .messages_c06487) {
+        :is(.messageContainer__95796, .messages__1ccd1) {
             @include boxes.inset;
             background: $bg;
 
             // Jump button
-            :is(.jumpButton_aab0bc, .jumpButton_ac3dc2) {
+            :is(.jumpButton_aab0bc, .jumpButton_ed0c8c) {
                 @include boxes.clickable($position: absolute);
             }
         }

--- a/scss/overlay/popovers/_incomingcall.scss
+++ b/scss/overlay/popovers/_incomingcall.scss
@@ -2,10 +2,10 @@
 @use "../../top/boxes" as boxes;
 
 // Incoming call alert
-.root_cbf230 {
+.root__2dbe1 {
     @include boxes.box;
 
-    .actionButton_cbf230 {
+    .actionButton__2dbe1 {
         @include boxes.clickable;
     }
 }

--- a/scss/overlay/popovers/_index.scss
+++ b/scss/overlay/popovers/_index.scss
@@ -21,7 +21,7 @@
 @use "../../top/boxes" as boxes;
 
 // Inner message scroller in pinned / inbox
-.layerContainer_cd0de5 [class^="header-"] + :is(.messagesPopout_ac90a2, .scrollerBase_eed6a8) {
+.layerContainer_da8173 [class^="header-"] + :is(.messagesPopout__45690, .scrollerBase__99f8c) {
     @include boxes.inset;
     margin: 0 6px 6px 6px;
 
@@ -31,6 +31,6 @@
 }
 
 // Max height for pinned / inbox
-.messagesPopoutWrap_ac90a2 {
+.messagesPopoutWrap__45690 {
     max-height: calc(100vh - $window-top - 120px) !important;
 }

--- a/scss/overlay/popovers/_loading.scss
+++ b/scss/overlay/popovers/_loading.scss
@@ -2,10 +2,10 @@
 @use "../../top/boxes" as boxes;
 
 // User profile (and other?) loading
-.loadingPopout_a8c724 {
+.loadingPopout__58f1c {
     @include boxes.box;
-    .path2_b6db20,
-    .path_b6db20 {
+    .path2__0b5bb,
+    .path__0b5bb {
         stroke: $blue;
     }
 }

--- a/scss/overlay/popovers/_menus.scss
+++ b/scss/overlay/popovers/_menus.scss
@@ -2,7 +2,7 @@
 @use "../../top/boxes" as boxes;
 
 // Small menus
-.menu_d90b3d {
+.menu_c1e9c4 {
     background: $grey;
     box-shadow: none;
     @include boxes.box;
@@ -11,47 +11,47 @@
         display: none;
     }
 
-    .scroller_d90b3d {
+    .scroller_c1e9c4 {
         padding: 0;
     }
 
     // Menu options
-    .colorDefault_d90b3d.focused_d90b3d,
-    .colorDefault_d90b3d:active:not(.hideInteraction_d90b3d) {
+    .colorDefault_c1e9c4.focused_c1e9c4,
+    .colorDefault_c1e9c4:active:not(.hideInteraction_c1e9c4) {
         background: $darkblue;
         color: $white;
     }
 
     // Blue options
-    .colorBrand_d90b3d {
+    .colorBrand_c1e9c4 {
         color: $blue;
     }
 
-    .submenuPaddingContainer_d90b3d {
+    .submenuPaddingContainer_c1e9c4 {
         padding: 0;
         margin: 0 -4px;
         background: $grey;
     }
 
     // Group labels
-    .groupLabel_d90b3d {
+    .groupLabel_c1e9c4 {
         text-transform: none;
     }
 
     // Checkbox
-    .icon_d90b3d:has(:is(.checkbox_d90b3d, path[d^="M12 20C16.4183"]), path[d^="M18.625 3"]) {
+    .icon_c1e9c4:has(:is(.checkbox_c1e9c4, path[d^="M12 20C16.4183"]), path[d^="M18.625 3"]) {
         @include boxes.inset;
         background: $white;
         width: 12px;
         height: 12px;
 
         // Checkbox
-        .checkbox_d90b3d,
+        .checkbox_c1e9c4,
         path[d^="M18.625 3"] {
             display: none;
         }
 
-        .check_d90b3d {
+        .check_c1e9c4 {
             color: $black;
         }
 
@@ -65,31 +65,31 @@
         }
 
         // Inner circle
-        .radioSelection_d90b3d {
+        .radioSelection_c1e9c4 {
             color: $black;
         }
     }
 
-    .colorDefault_d90b3d.focused_d90b3d .caret_d90b3d,
-    .colorDefault_d90b3d.focused_d90b3d .checkbox_d90b3d,
-    .colorDefault_d90b3d.focused_d90b3d .radioSelection_d90b3d {
+    .colorDefault_c1e9c4.focused_c1e9c4 .caret_c1e9c4,
+    .colorDefault_c1e9c4.focused_c1e9c4 .checkbox_c1e9c4,
+    .colorDefault_c1e9c4.focused_c1e9c4 .radioSelection_c1e9c4 {
         color: $black;
     }
 
     // Slider
-    .mini_c7a159 {
-        .bar_c7a159 {
+    .mini_a562c8 {
+        .bar_a562c8 {
             height: 4px;
         }
 
-        .grabber_c7a159 {
+        .grabber_a562c8 {
             height: 16px;
             width: 10px;
         }
     }
 
     // Quick reacts
-    .button_a24e84 {
+    .button_f563df {
         @include boxes.clickable;
         padding: 0;
         margin-top: 4px;

--- a/scss/overlay/popovers/_moretags.scss
+++ b/scss/overlay/popovers/_moretags.scss
@@ -2,10 +2,10 @@
 @use "../../top/boxes" as boxes;
 
 // See more tags creating forum post with narrow screen
-.container_ac201b {
+.container__3dde2 {
     @include boxes.box;
 
-    .searchWithScrollbar_eef3ef {
+    .searchWithScrollbar__97e86 {
         @include boxes.inset;
         background: $bg;
 
@@ -14,16 +14,16 @@
         }
     }
 
-    .list_eef3ef {
+    .list__97e86 {
         @include boxes.scroller;
         margin: 1px;
         padding: 0;
 
-        .item_eef3ef {
+        .item__97e86 {
             @include boxes.clickable;
             margin: 0;
 
-            &.selected_eef3ef {
+            &.selected__97e86 {
                 @include boxes.inset;
             }
         }

--- a/scss/overlay/popovers/_pinned.scss
+++ b/scss/overlay/popovers/_pinned.scss
@@ -2,19 +2,19 @@
 @use "../../top/boxes" as boxes;
 
 // Pinned messages
-.messagesPopoutWrap_ac90a2 {
+.messagesPopoutWrap__45690 {
     @include boxes.box;
 
-    .header_ac90a2 {
+    .header__45690 {
         padding: 6px;
         box-shadow: none;
     }
 
-    .messageGroupWrapper_ac90a2 {
+    .messageGroupWrapper__45690 {
         @include boxes.inset;
         background: $bg;
 
-        .jumpButton_ac90a2 {
+        .jumpButton__45690 {
             @include boxes.clickable;
         }
     }

--- a/scss/overlay/popovers/_regionselect.scss
+++ b/scss/overlay/popovers/_regionselect.scss
@@ -3,7 +3,7 @@
 
 // Select region in DM VC
 
-.layerContainer_cd0de5 .quickSelectPopout__56a98 {
+.layerContainer_da8173 .quickSelectPopout_ebaca5 {
     @include boxes.box($position: absolute);
     top: -8px;
     background: $grey;
@@ -14,12 +14,12 @@
         color: $white;
     }
 
-    .regionSelectName_ccb5ca {
+    .regionSelectName__5621e {
         color: inherit;
         margin: 0;
     }
 
-    .check_ccb5ca {
+    .check__5621e {
         background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='12'%3E%3Cpath fill='none' stroke='%23000' stroke-width='3' d='M1.99609375 5.7835338l3.70287382 3.7028738L14.1853752 1'/%3E%3C/svg%3E");
     }
 }

--- a/scss/overlay/popovers/_search.scss
+++ b/scss/overlay/popovers/_search.scss
@@ -3,14 +3,14 @@
 @use "../../top/channellist-css" as channels;
 
 // Search popover
-.container_eedf95 {
+.container__55c99 {
     @include boxes.box;
     @include channels.vars;
 
     // Search option categories
-    .resultsGroup_b0286e {
+    .resultsGroup__56fec {
         // Section title
-        .header_b0286e {
+        .header__56fec {
             color: var(--header-primary);
         }
 
@@ -20,7 +20,7 @@
         }
 
         // Right corner icon
-        :is(.searchClearHistory_b0286e, .searchLearnMore_b0286e) {
+        :is(.searchClearHistory__56fec, .searchLearnMore__56fec) {
             @include boxes.clickable($position: absolute);
 
             &:hover {
@@ -35,18 +35,18 @@
     }
 
     // Search options
-    .option_b0286e {
+    .option__56fec {
         margin: 0;
 
         // Hovered stuff
         &:hover
             :is(
-                .nonText_b0286e,
-                .displayedNick_b0286e,
-                .displayUsername_b0286e,
+                .nonText__56fec,
+                .displayedNick__56fec,
+                .displayUsername__56fec,
                 strong,
-                .searchResultChannelCategory_b0286e,
-                .searchResultChannelIcon_b0286e
+                .searchResultChannelCategory__56fec,
+                .searchResultChannelIcon__56fec
             ) {
             color: var(--interactive-hover);
         }
@@ -59,7 +59,7 @@
         }
 
         // Search history term
-        .nonText_b0286e {
+        .nonText__56fec {
             color: var(--text-muted);
         }
 
@@ -70,7 +70,7 @@
     }
 
     // Calendar
-    .calendarPicker__47c85 {
+    .calendarPicker_d27f17 {
         :is(.react-datepicker, .react-datepicker__header) {
             background: $grey;
         }
@@ -163,22 +163,22 @@
     }
 
     // Date picker hint
-    .datePickerHint_b0286e {
+    .datePickerHint__56fec {
         @include boxes.box;
         margin: 0;
         padding: 8px 20px;
 
-        .hintValue_b0286e {
+        .hintValue__56fec {
             @include boxes.clickable;
         }
     }
 
     // Search query
-    .queryContainer_eedf95 {
+    .queryContainer__55c99 {
         @include boxes.clickable;
         background: $grey;
 
-        .queryText_eedf95 {
+        .queryText__55c99 {
             text-transform: none;
             color: $darkgrey;
 

--- a/scss/overlay/popovers/_soundboard.scss
+++ b/scss/overlay/popovers/_soundboard.scss
@@ -1,12 +1,12 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.picker_cd703d {
+.picker__09f65 {
     @include boxes.box;
 }
 
 // Soundboard volume
-.settingsClickArea_ca5acd {
+.settingsClickArea__61424 {
     @include boxes.clickable;
     margin-left: 0;
     box-sizing: border-box;
@@ -18,17 +18,17 @@
 }
 
 // Category list
-.categoryList_ceda83 {
+.categoryList_a1e0e0 {
     @include boxes.box($position: absolute);
     top: 61px;
 
-    .listItems_dcade6 {
+    .listItems_affa7e {
         inset: 6px !important;
     }
 }
 
 // Category icon
-.category_ceda83 {
+.category_a1e0e0 {
     @include boxes.clickable;
     margin-bottom: 0;
     height: 36px;
@@ -36,12 +36,12 @@
 }
 
 // Sounds panel
-.wrapper_cdfd51 {
+.wrapper_d852db {
     background: $bg;
 }
 
 // Category header
-.sectionHeader_ca5acd {
+.sectionHeader__61424 {
     background: $grey;
     @include boxes.box;
     inset: -8px 0 0 -8px;
@@ -51,15 +51,15 @@
 }
 
 // Button arrangement
-.soundRow_ca5acd {
+.soundRow__61424 {
     gap: 0;
 
-    &:not(:has(+ .sectionHeader_ca5acd)) {
+    &:not(:has(+ .sectionHeader__61424)) {
         margin-bottom: 0;
     }
 }
 
 // Sound
-.soundButton_f40049 {
+.soundButton__6d4ed {
     @include boxes.clickable;
 }

--- a/scss/overlay/popovers/_threads.scss
+++ b/scss/overlay/popovers/_threads.scss
@@ -2,16 +2,16 @@
 @use "../../top/boxes" as boxes;
 
 // Threads
-.browser_f542fc {
+.browser_d98031 {
     @include boxes.box;
 
-    .header_e664f3 {
-        .divider_e664f3,
-        .spacer_e664f3 {
+    .header_d9c882 {
+        .divider_d9c882,
+        .spacer_d9c882 {
             display: none;
         }
 
-        .searchBox_e664f3 {
+        .searchBox_d9c882 {
             @include boxes.inset;
             background: $bg;
 
@@ -25,26 +25,26 @@
             }
         }
 
-        .createButton_e664f3 {
+        .createButton_d9c882 {
             height: 26px;
         }
 
-        .closeIcon_e664f3 {
+        .closeIcon_d9c882 {
             @include boxes.clickable;
             height: 24px;
         }
 
-        .searchBox_e664f3,
-        .createButton_e664f3 {
+        .searchBox_d9c882,
+        .createButton_d9c882 {
             margin-right: 0;
         }
     }
 
-    .container_acb8b3 {
+    .container__6764b {
         @include boxes.clickable;
     }
 
-    .jump_d5deea {
+    .jump__5126c {
         @include boxes.clickable($position: absolute);
     }
 }

--- a/scss/overlay/popovers/_toasts.scss
+++ b/scss/overlay/popovers/_toasts.scss
@@ -1,6 +1,6 @@
 @use "../../top/vars" as *;
 @use "../../top/boxes" as boxes;
 
-.toast_f42767 {
+.toast__3fde7 {
     @include boxes.box;
 }

--- a/scss/overlay/popovers/_userprofiles.scss
+++ b/scss/overlay/popovers/_userprofiles.scss
@@ -15,7 +15,7 @@
             --header-secondary: #{$grey};
             --text-normal: #{$lightgrey};
 
-            .color_f1cdcc.banner_f1cdcc {
+            .color_f9d37d.banner_fb7f94 {
                 color: #{$white};
             }
         }
@@ -31,18 +31,18 @@
         .profileBadges_f89da9 {
             gap: 0;
             padding: 0;
-            .anchor_af404b {
+            .anchor_edefb8 {
                 @include boxes.clickable;
                 padding: 2px;
             }
         }
 
         // Profile badges (new profile)
-        .container_e5a42d {
+        .container__8061a {
             @include boxes.box;
         }
 
-        .color_f1cdcc.banner_f1cdcc {
+        .color_f9d37d.banner_fb7f94 {
             background: none;
         }
 
@@ -62,12 +62,12 @@
         }
 
         code,
-        .blockquoteDivider_f8f345 {
+        .blockquoteDivider__75297 {
             background: $darkgrey;
         }
 
         // Roles
-        :is(.role_f9575e, .showMoreButton_c83b44) {
+        :is(.role_dfa8b6, .showMoreButton_c83b44) {
             @include boxes.box;
             margin-right: 0;
         }
@@ -83,7 +83,7 @@
         }
 
         // Activity buttons
-        .vertical_bf8eca > :not(:first-child) {
+        .vertical__65bb6 > :not(:first-child) {
             margin-top: 0;
         }
     }

--- a/scss/overlay/popovers/_vc.scss
+++ b/scss/overlay/popovers/_vc.scss
@@ -2,46 +2,46 @@
 @use "../../top/boxes" as boxes;
 
 // VC emoji picker
-.container_bdea70 {
+.container__0800c {
     @include boxes.box;
 
-    .categoryList_c6ee36 {
+    .categoryList_c0e32c {
         top: 52px;
     }
 
-    .slotsContainer_bdea70 {
+    .slotsContainer__0800c {
         @include boxes.box;
         padding: 4px;
         width: auto;
 
-        .slotsWide_bdea70 {
+        .slotsWide__0800c {
             gap: 8px;
         }
 
-        .slot_bdea70 {
+        .slot__0800c {
             @include boxes.clickable;
             padding: 4px;
         }
 
         // Do not popout with hover
-        .contents_dd4f85 > div {
+        .contents__201d5 > div {
             transform: none !important;
         }
     }
 }
 
 // VC activity picker
-.container_b572de {
+.container__9fa5a {
     @include boxes.box;
 
     // Activity
-    .activityItem_13_11_ec77c5 {
+    .activityItem_13_11__8a940 {
         @include boxes.clickable;
         transform: none !important;
     }
 
     // No animation
-    .wumpusRocketOuterContainer_b572de {
+    .wumpusRocketOuterContainer__9fa5a {
         display: none;
     }
 }

--- a/scss/overlay/settings/_index.scss
+++ b/scss/overlay/settings/_index.scss
@@ -7,13 +7,13 @@
 @use "../../top/channellist-css" as channels;
 
 // Toggles
-.control_ed1d57 {
+.control__0d850 {
     @include boxes.box;
 
-    .container_cebd1c {
+    .container__87bf1 {
         background: $darkgrey !important;
 
-        .slider_cebd1c {
+        .slider__87bf1 {
             rect {
                 fill: $lightgrey;
             }
@@ -22,10 +22,10 @@
             }
         }
 
-        &.checked_cebd1c {
+        &.checked__87bf1 {
             background: $green !important;
 
-            .slider_cebd1c {
+            .slider__87bf1 {
                 svg path {
                     fill: $green;
                 }
@@ -35,25 +35,25 @@
 }
 
 // Notices
-.formNotice_aae945 {
+.formNotice_f43ba5 {
     @include boxes.box;
 }
 
 // Sliders
-.slider_c7a159 {
+.slider_a562c8 {
     // Slider bar
-    .bar_c7a159 {
+    .bar_a562c8 {
         @include boxes.inset;
         background: $grey;
         height: 8px;
 
-        .barFill_c7a159 {
+        .barFill_a562c8 {
             background: transparent;
         }
     }
 
     // Slider handle
-    .grabber_c7a159 {
+    .grabber_a562c8 {
         @include boxes.box;
         background: $grey;
         height: 20px;
@@ -66,12 +66,12 @@
     }
 
     // Slider marks
-    .mark_c7a159 {
-        &:not(.defaultValue_c7a159) .markValue_c7a159 {
+    .mark_a562c8 {
+        &:not(.defaultValue_a562c8) .markValue_a562c8 {
             color: $black;
         }
 
-        .markDash_c7a159 {
+        .markDash_a562c8 {
             background: $black;
             height: 6px;
             width: 1px;
@@ -81,13 +81,13 @@
 }
 
 // Checkbox
-.checkboxWrapper_f6cde8 {
-    .inputDefault_f6cde8 {
+.checkboxWrapper_f525d3 {
+    .inputDefault_f525d3 {
         width: 20px !important;
         height: 20px !important;
     }
 
-    .checkbox_f6cde8 {
+    .checkbox_f525d3 {
         width: 20px !important;
         height: 20px !important;
         border: 2px solid $black !important;
@@ -97,23 +97,23 @@
             d: path("M 3 3 V 21 H 21 V 3 Z");
         }
 
-        &.checked_f6cde8 path {
+        &.checked_f525d3 path {
             fill: $black;
         }
     }
 }
 
 // Dropdown selectors
-.lookFilled_f6639d.select_f6639d {
+.lookFilled__3f413.select__3f413 {
     @include boxes.inset;
     padding: 0;
 
-    .value_f6639d {
+    .value__3f413 {
         padding-left: 8px;
         color: $text;
     }
 
-    .icons_f6639d {
+    .icons__3f413 {
         background: $grey;
         @include boxes.box;
     }

--- a/scss/overlay/settings/serversettings/_index.scss
+++ b/scss/overlay/settings/serversettings/_index.scss
@@ -7,8 +7,8 @@
     display: none;
 }
 
-.h5_c46f6a,
-.label_c46f6a,
-.legend_c46f6a {
+.h5_b717a1,
+.label_b717a1,
+.legend_b717a1 {
     color: #{$black};
 }

--- a/scss/overlay/settings/serversettings/_members.scss
+++ b/scss/overlay/settings/serversettings/_members.scss
@@ -5,7 +5,7 @@
     @include boxes.box;
     padding: 15px;
 
-    .role_f9575e {
+    .role_dfa8b6 {
         @include boxes.clickable;
         cursor: pointer;
     }

--- a/scss/overlay/settings/usersettings/_appearance.scss
+++ b/scss/overlay/settings/usersettings/_appearance.scss
@@ -2,28 +2,28 @@
 @use "../../../top/boxes" as boxes;
 
 #appearance-tab {
-    .preview_a614a7 {
+    .preview__3e443 {
         background: $bg;
         @include boxes.inset;
     }
 
-    .presets_f45ea6 {
+    .presets__67a11 {
         gap: 8px;
 
-        .themeSelection_cb7c27 {
+        .themeSelection__36dee {
             box-shadow: none;
             @include boxes.clickable;
 
-            &.selected_cb7c27 {
+            &.selected__36dee {
                 @include boxes.inset;
             }
 
-            &.darkIcon_cb7c27 {
+            &.darkIcon__36dee {
                 background: $black;
             }
         }
 
-        .selectionCircle_cb7c27 {
+        .selectionCircle__36dee {
             display: none;
         }
     }

--- a/scss/overlay/settings/usersettings/_authorisedapps.scss
+++ b/scss/overlay/settings/usersettings/_authorisedapps.scss
@@ -2,12 +2,12 @@
 @use "../../../top/boxes" as boxes;
 
 // # Authorised apps
-.authedApp_f0135d {
+.authedApp__50a54 {
     @include boxes.box;
     border-color: $white $black $black $white !important;
     padding: 8px;
 
-    .marginTop20_f7730b {
+    .marginTop20_fd297e {
         @include boxes.inset;
         padding: 4px;
     }

--- a/scss/overlay/settings/usersettings/_billing.scss
+++ b/scss/overlay/settings/usersettings/_billing.scss
@@ -2,13 +2,13 @@
 @use "../../../top/boxes" as boxes;
 
 #billing-tab {
-    .codeRedemptionRedirect_cb70f4 {
+    .codeRedemptionRedirect_a706ba {
         background: $grey;
         color: $black;
         @include boxes.box;
     }
 
-    .subText_edf4d6 {
+    .subText__0eeee {
         color: $darkgrey;
     }
 }

--- a/scss/overlay/settings/usersettings/_connections.scss
+++ b/scss/overlay/settings/usersettings/_connections.scss
@@ -2,33 +2,33 @@
 @use "../../../top/boxes" as boxes;
 
 // # Connections
-.connectContainer_e2a436 {
+.connectContainer_c7f964 {
     @include boxes.box;
     padding: 8px;
 
-    .connectionsContainer_e2a436 {
+    .connectionsContainer_c7f964 {
         margin-top: 4px;
         gap: 0;
 
-        .inner_c36ce4,
-        .accountAddInner_e2a436 {
+        .inner__02fc8,
+        .accountAddInner_c7f964 {
             @include boxes.clickable;
         }
     }
 }
 
-.connectionList_e2a436 {
+.connectionList_c7f964 {
     grid-gap: 0;
 
-    .connection_e2a436 {
+    .connection_c7f964 {
         @include boxes.box;
         padding: 0;
         margin-bottom: 0;
 
-        .connectionHeader_e2a436 {
+        .connectionHeader_c7f964 {
             padding: 8px;
 
-            .connectionDelete_e2a436 {
+            .connectionDelete_c7f964 {
                 margin: 0;
                 align-self: flex-start;
 
@@ -40,7 +40,7 @@
             }
         }
 
-        .upsellWrapper_e2a436 {
+        .upsellWrapper_c7f964 {
             padding: 8px;
 
             .container-QlmnKJ {
@@ -49,16 +49,16 @@
             }
         }
 
-        .metadataContainer_e2a436 {
+        .metadataContainer_c7f964 {
             padding: 0 8px;
             margin: 0;
         }
 
-        .connectionOptionsWrapper_e2a436 {
+        .connectionOptionsWrapper_c7f964 {
             padding: 8px;
 
-            .connectionOptions_e2a436 {
-                .connectionOptionSwitch_e2a436 {
+            .connectionOptions_c7f964 {
+                .connectionOptionSwitch_c7f964 {
                     margin-bottom: 0px;
                     padding: 0;
                 }

--- a/scss/overlay/settings/usersettings/_devices.scss
+++ b/scss/overlay/settings/usersettings/_devices.scss
@@ -2,11 +2,11 @@
 @use "../../../top/boxes" as boxes;
 
 // # Devices
-.session_c7a2c0 {
+.session__803f2 {
     @include boxes.box;
     padding: 8px;
 
-    .sessionMoreButton_c7a2c0 {
+    .sessionMoreButton__803f2 {
         svg {
             @include boxes.clickable;
         }

--- a/scss/overlay/settings/usersettings/_gameoverlay.scss
+++ b/scss/overlay/settings/usersettings/_gameoverlay.scss
@@ -2,15 +2,15 @@
 @use "../../../top/boxes" as boxes;
 
 // Overlay notification position
-.wrapper_d2da9c {
+.wrapper_e03935 {
     border: 2px solid $darkblue;
     background: transparent;
 
-    .option_d2da9c {
+    .option_e03935 {
         @include boxes.clickable($position: absolute);
         background: $grey;
 
-        &.selected_d2da9c,
+        &.selected_e03935,
         &:hover {
             background-color: $darkblue;
             box-shadow: none;

--- a/scss/overlay/settings/usersettings/_giftinventory.scss
+++ b/scss/overlay/settings/usersettings/_giftinventory.scss
@@ -1,9 +1,9 @@
 @use "../../../top/vars" as *;
 
 #library-inventory-tab {
-    .codeRedemptionInput_c9555c {
+    .codeRedemptionInput__3514e {
         margin-right: 0;
-        .input_f8bc55 {
+        .input__0f084 {
             height: 100%;
         }
     }
@@ -13,9 +13,9 @@
     }
 }
 
-.emptyState_e8af36 {
-    .emptyStateHeader_e8af36,
-    .emptyStateSubtext_e8af36 {
+.emptyState_d4883c {
+    .emptyStateHeader_d4883c,
+    .emptyStateSubtext_d4883c {
         color: $black;
     }
 }

--- a/scss/overlay/settings/usersettings/_index.scss
+++ b/scss/overlay/settings/usersettings/_index.scss
@@ -23,57 +23,57 @@
 @use "../../../top/channellist-css" as channels;
 
 // User settings menu
-.standardSidebarView_c25c6d {
+.standardSidebarView__23e6b {
     padding-top: $title-height;
     margin-bottom: $window-bottom + 46px;
 
     // Unsaved changes
-    .container_b6cd66 {
+    .container_fcf29c {
         @include boxes.box;
         background: $grey !important;
 
-        .message_b6cd66,
-        .contents_dd4f85 span {
+        .message_fcf29c,
+        .contents__201d5 span {
             color: $black !important;
         }
     }
 
-    .sidebarRegion_c25c6d {
+    .sidebarRegion__23e6b {
         @include channels.vars;
         flex-grow: 0;
 
-        .sidebar_c25c6d {
+        .sidebar__23e6b {
             padding: 0;
         }
 
-        .separator_a0 {
+        .separator_b3f026 {
             display: none;
         }
 
-        .header_a0 {
+        .header_b3f026 {
             margin-top: 12px;
         }
     }
 
-    .contentRegionShownSidebar_c25c6d {
+    .contentRegionShownSidebar__23e6b {
         justify-content: center;
 
-        .contentColumnDefault_c25c6d,
-        .contentColumnWide_c25c6d {
+        .contentColumnDefault__23e6b,
+        .contentColumnWide__23e6b {
             padding: 10px;
             @include boxes.box;
         }
 
         // Close settings button
-        .toolsContainer_c25c6d {
+        .toolsContainer__23e6b {
             padding-top: 20px;
             margin-right: 0;
             position: absolute;
             left: -300px;
             z-index: 1;
 
-            .container_df5532 {
-                .closeButton_df5532 {
+            .container_c2b141 {
+                .closeButton_c2b141 {
                     @include boxes.clickable;
                     background: $grey;
                     margin-bottom: 8px;
@@ -88,7 +88,7 @@
                     color: $white;
                 }
 
-                .keybind_df5532 {
+                .keybind_c2b141 {
                     display: none;
                 }
             }

--- a/scss/overlay/settings/usersettings/_keybinds.scss
+++ b/scss/overlay/settings/usersettings/_keybinds.scss
@@ -1,40 +1,40 @@
 @use "../../../top/vars" as *;
 @use "../../../top/boxes" as boxes;
 
-.warning_f20685 {
+.warning__6436f {
     @include boxes.box;
 }
 
-.marginTop60_f7730b {
+.marginTop60_fd297e {
     margin-top: 16px;
 }
 
-.defaultKeybindGroup_f916fc {
+.defaultKeybindGroup__740f2 {
     margin: 16px 0 0;
 
-    .defaultKeybindGroupHeader_f916fc,
-    .defaultKeybindGroupDescription_f916fc {
+    .defaultKeybindGroupHeader__740f2,
+    .defaultKeybindGroupDescription__740f2 {
         margin-bottom: 8px;
     }
 }
 
-.defaultKeybind_f916fc {
+.defaultKeybind__740f2 {
     padding: 4px;
     height: 32px;
     @include boxes.inset;
 
-    &:has(.combo_c90023:nth-child(2)) {
+    &:has(.combo_fcddc1:nth-child(2)) {
         height: 64px;
     }
 }
 
-.appMount_ea7e65 .combo_c90023 {
+.appMount__51fd7 .combo_fcddc1 {
     text-transform: capitalize;
     font-weight: unset;
     font-size: 14px;
     line-height: 16px;
 
-    .key_c90023 {
+    .key_fcddc1 {
         @include boxes.box;
         box-shadow: none;
         background: $darkgrey;

--- a/scss/overlay/settings/usersettings/_myaccount.scss
+++ b/scss/overlay/settings/usersettings/_myaccount.scss
@@ -2,20 +2,20 @@
 @use "../../../top/boxes" as boxes;
 
 // # My Account
-.accountProfileCard_b69b77 {
+.accountProfileCard__1fed1 {
     @include boxes.box;
 
-    .background_b69b77 {
+    .background__1fed1 {
         @include boxes.inset;
     }
 
-    .overflowMenuIcon_b69b77 {
+    .overflowMenuIcon__1fed1 {
         @include boxes.clickable;
     }
 
-    .badgeList_b69b77 {
+    .badgeList__1fed1 {
         gap: 0;
-        .anchor_af404b {
+        .anchor_edefb8 {
             @include boxes.clickable;
         }
     }

--- a/scss/overlay/settings/usersettings/_nitro.scss
+++ b/scss/overlay/settings/usersettings/_nitro.scss
@@ -1,15 +1,15 @@
 @use "../../../top/vars" as *;
 @use "../../../top/boxes" as boxes;
 
-.perkCardsContainerSpacingSettings_a8b566,
-.premiumTierCardsContainerSettings_a8b566,
-.perksTitle_d611db,
-.titleText_b1bbf4 {
+.perkCardsContainerSpacingSettings_c880e8,
+.premiumTierCardsContainerSettings_c880e8,
+.perksTitle_b62c4e,
+.titleText_e4ef5c {
     margin-bottom: 8px;
 }
 
-.container_f26610,
-.card_c87d73 {
+.container__81281,
+.card_ac86f6 {
     @include boxes.inset;
     padding: 16px;
 }
@@ -19,7 +19,7 @@
     width: 100%;
 }
 
-.premiumCards_c87d73 {
+.premiumCards_ac86f6 {
     gap: 0;
 }
 
@@ -37,7 +37,7 @@
     }
 }
 
-.table_b1bbf4 {
+.table_e4ef5c {
     @include boxes.box;
     tbody :is(th, td) {
         @include boxes.inset;
@@ -45,7 +45,7 @@
     th {
         padding: 4px;
     }
-    .row_b1bbf4 {
+    .row_e4ef5c {
         height: auto;
     }
     .buttonsCell-gSFzSA {
@@ -59,7 +59,7 @@
     padding-bottom: 8px;
 }
 
-.bottomIllustration_a8b566 {
+.bottomIllustration_c880e8 {
     position: fixed;
     bottom: 0;
 }

--- a/scss/overlay/settings/usersettings/_privacyandsafety.scss
+++ b/scss/overlay/settings/usersettings/_privacyandsafety.scss
@@ -2,7 +2,7 @@
 @use "../../../top/boxes" as boxes;
 
 // # Privacy and safety
-.item_eb92a8 {
+.item__001a7 {
     @include boxes.clickable;
     margin: 0;
 
@@ -10,11 +10,11 @@
         @include boxes.inset;
     }
 
-    .radioBar_eb92a8 {
+    .radioBar__001a7 {
         padding: 4px !important;
     }
 }
 
-.marginBottom40_f7730b {
+.marginBottom40_fd297e {
     margin-bottom: 20px;
 }

--- a/scss/overlay/settings/usersettings/_profiles.scss
+++ b/scss/overlay/settings/usersettings/_profiles.scss
@@ -3,54 +3,54 @@
 
 // # Profiles
 // Tabs
-.tabBar_bff66b {
+.tabBar_d6f9e9 {
     margin-top: 0;
 
-    .brand_a0.item_a0 {
+    .brand_b3f026.item_b3f026 {
         @include boxes.clickable;
         padding: 4px;
         margin: 0;
 
         &:active,
         &:hover,
-        &.selected_a0 {
+        &.selected_b3f026 {
             border-bottom-color: $darkblue;
         }
 
-        &.selected_a0 {
+        &.selected_b3f026 {
             @include boxes.inset;
         }
     }
 }
 
 // Remove section dividers
-.customizationSection_b3a5c2 {
+.customizationSection_ace4f5 {
     border-bottom: 0;
     margin-bottom: 0;
 }
 
 // Banner colour picker
-.colorSwatch_c66781 {
+.colorSwatch__2d060 {
     @include boxes.inset;
 }
 
 // Bio typing area
-.channelTextArea_d0696b {
+.channelTextArea__74017 {
     @include boxes.inset;
 
-    .slateTextArea_e52116 {
+    .slateTextArea_ec4baf {
         // maybe risky to other textboxes, doublecheck
         padding: 4px !important;
     }
 }
 
 // Emoji picker button
-.webkit__8d35a .buttons_d0696b {
+.webkit__8d35a .buttons__74017 {
     margin-right: 0;
 }
 
 // Characters left
-.characterCount_b82429 {
+.characterCount__795fb {
     right: 24px;
     bottom: 0;
 }
@@ -73,17 +73,17 @@
 }
 
 // Nitro upsell lol
-.premiumFeatureBorder_c6d722,
-.premiumBackground_c6d722 {
+.premiumFeatureBorder__65c15,
+.premiumBackground__65c15 {
     background: none;
 }
 
 // Server nickname
-.inputWrapper_f8bc55 {
+.inputWrapper__0f084 {
     @include boxes.inset;
     background: $bg;
 
-    .input_f8bc55 {
+    .input__0f084 {
         padding: 0 4px;
         height: 24px;
         color: $text;

--- a/scss/overlay/settings/usersettings/_registeredgames.scss
+++ b/scss/overlay/settings/usersettings/_registeredgames.scss
@@ -2,28 +2,28 @@
 @use "../../../top/boxes" as boxes;
 
 #game-activity-tab {
-    .gameName_fd966d {
+    .gameName_cc46f0 {
         color: $black;
     }
 
-    .lastPlayed_fd966d,
+    .lastPlayed_cc46f0,
     .overlayStatusText__668e1 {
         color: $darkgrey;
     }
 
-    .activeGame_fd966d {
+    .activeGame_cc46f0 {
         @include boxes.box;
     }
 
-    .nowPlayingAdd_fd966d {
+    .nowPlayingAdd_cc46f0 {
         color: $black;
     }
 
-    .card_ffe375 {
+    .card_b846e5 {
         @include boxes.box;
         padding: 8px;
 
-        .gameNameInput_fd966d {
+        .gameNameInput_cc46f0 {
             &:focus,
             &:hover {
                 background: $white;
@@ -34,7 +34,7 @@
         .overlayToggleIcon-1WRcQ9 {
             @include boxes.clickable;
 
-            .overlayToggleIconOn-21NN2N .fill_fd966d {
+            .overlayToggleIconOn-21NN2N .fill_cc46f0 {
                 fill: $darkgrey;
             }
 
@@ -43,12 +43,12 @@
             }
         }
 
-        .flowerStar_ff7d90 path {
+        .flowerStar__3e3b0 path {
             fill: $darkblue;
         }
     }
 
-    .removeGame_fd966d {
+    .removeGame_cc46f0 {
         @include boxes.clickable($position: absolute);
         right: -12px;
         background-color: $grey;
@@ -57,11 +57,11 @@
 }
 
 // Technically a popover
-.animatorBottom_f88ae3 .addGamePopout_fd966d {
+.animatorBottom_faf9c0 .addGamePopout_cc46f0 {
     background: $grey;
     @include boxes.box;
 
-    .actions_fd966d {
+    .actions_cc46f0 {
         margin-top: 8px;
     }
 }

--- a/scss/overlay/settings/usersettings/_serverboost.scss
+++ b/scss/overlay/settings/usersettings/_serverboost.scss
@@ -54,6 +54,6 @@
     }
 }
 
-.tier0Heading_dc391a {
+.tier0Heading__176c7 {
     margin-bottom: 8px;
 }

--- a/scss/overlay/settings/usersettings/_subscriptions.scss
+++ b/scss/overlay/settings/usersettings/_subscriptions.scss
@@ -8,17 +8,17 @@
     border-bottom: 0;
 }
 
-.card_a298b8 {
+.card__73069 {
     @include boxes.inset;
     padding: 16px;
 
-    .noItemsIcon_a206c7,
-    .noItemsIcon_e70817 {
+    .noItemsIcon_e335a7,
+    .noItemsIcon__70151 {
         background: transparent;
     }
 
-    .cardText_a206c7,
-    .cardText_e70817 {
+    .cardText_e335a7,
+    .cardText__70151 {
         color: $black;
     }
 }

--- a/scss/overlay/settings/usersettings/_voiceandvideo.scss
+++ b/scss/overlay/settings/usersettings/_voiceandvideo.scss
@@ -11,6 +11,6 @@
 }
 
 // Shortcut edit
-.editIcon_ebcd80 {
+.editIcon__2636e {
     background: url("data:image/svg+xml,%3Csvg height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M 22 5 H 2 L 2 19 H 22 Z M 11 8 H 13 V 10 H 11 Z M 11 11 H 13 V 13 H 11 Z M 8 8 H 10 V 10 H 8 Z M 8 11 H 10 V 13 H 8 Z M 7 13 H 5 V 11 H 7 Z M 7 10 H 5 V 8 H 7 Z M 16 17 H 8 V 15 H 16 Z M 16 13 H 14 V 11 H 16 Z M 16 10 H 14 V 8 H 16 Z M 19 13 H 17 V 11 H 19 Z M 19 10 H 17 V 8 H 19 Z' fill='%23000' fill-rule='nonzero'/%3E%3Cpath d='m0 0h24v24h-24zm0 0h24v24h-24z'/%3E%3C/g%3E%3C/svg%3E");
 }

--- a/scss/part/_buttons.scss
+++ b/scss/part/_buttons.scss
@@ -2,29 +2,29 @@
 @use "../top/boxes" as boxes;
 
 :is(
-        .button_b9fe76,
-        .welcomeCTAButtonOuter_f6dde0,
-        .friendRequestsButton_c0c071,
-        .button__292b6,
-        .lookFilled_dd4f85,
-        .lookOutlined_dd4f85,
-        .lookInverted_a299dc
-    ) {
+    .button_d5f3cd,
+    .welcomeCTAButtonOuter_f5d1e2,
+    .friendRequestsButton__523aa,
+    .button__292b6,
+    .lookFilled__201d5,
+    .lookOutlined__201d5,
+    .lookInverted_a299dc
+) {
     @include boxes.clickable;
 }
 
 :is(.theme-dark, .theme-light) {
-    .lookLink_dd4f85.colorPrimary_dd4f85 {
+    .lookLink__201d5.colorPrimary__201d5 {
         color: $black;
 
-        &:hover .contents_dd4f85 {
+        &:hover .contents__201d5 {
             --button--underline-color: #{$black};
         }
     }
 }
 
-.appMount_ea7e65 .lookFilled_dd4f85 {
-    &:is(.colorBrand_dd4f85, .colorBrand_dd4f85:disabled, .colorBrand_dd4f85[aria-disabled="true"], .colorBrandNew__8872c) {
+.appMount__51fd7 .lookFilled__201d5 {
+    &:is(.colorBrand__201d5, .colorBrand__201d5:disabled, .colorBrand__201d5[aria-disabled="true"], .colorBrandNew__8872c) {
         color: $black;
         background: $lightgrey;
 
@@ -34,7 +34,7 @@
         }
     }
 
-    &:is(.colorPrimary_dd4f85, .colorTransparent_dd4f85) {
+    &:is(.colorPrimary__201d5, .colorTransparent__201d5) {
         color: $black;
     }
 }

--- a/scss/part/_css-vars.scss
+++ b/scss/part/_css-vars.scss
@@ -41,8 +41,8 @@
 
 // Colour sync stuff
 :root {
-    .container_f1fd9c,
-    .header_f1fd9c,
+    .container__0b563,
+    .header__0b563,
     .container_c2efea {
         background: var(--background-primary);
     }

--- a/scss/part/_darkmode.scss
+++ b/scss/part/_darkmode.scss
@@ -2,14 +2,14 @@
 $prefix: "https://canary.discord.com";
 
 .theme-light {
-    .calendarPicker__47c85 .react-datepicker__navigation.react-datepicker__navigation--next,
-    .calendarPicker__47c85 .react-datepicker__navigation.react-datepicker__navigation--previous {
+    .calendarPicker_d27f17 .react-datepicker__navigation.react-datepicker__navigation--next,
+    .calendarPicker_d27f17 .react-datepicker__navigation.react-datepicker__navigation--previous {
         background-image: url($prefix + "/assets/7619529e87dad31fd2ae83d9b9583e49.svg");
     }
-    .wrapper_b06619 {
+    .wrapper__61a6b {
         background-image: url($prefix + "/assets/86548cb347b5acfb41bcb328c89b9bdc.svg");
     }
-    .image_b06619 {
+    .image__61a6b {
         background-image: url($prefix + "/assets/5656f17248cf747f56433a1d60c8c1bf.svg");
     }
     .conflictUploadArt_c68c28 {
@@ -24,46 +24,46 @@ $prefix: "https://canary.discord.com";
     .authBox_dc6abe .discordLogo_dc6abe {
         background: url($prefix + "/assets/22fd790491653d837422d80e3500cf92.svg") no-repeat;
     }
-    .cardFormHeader_c7dd62.jcb_c7dd62:before {
+    .cardFormHeader__3e8d5.jcb__3e8d5:before {
         background-image: url($prefix + "/assets/2f837517dadf32743c343c0692856dbb.svg");
     }
-    .cardFormHeader_c7dd62.jcb_monochrome_c7dd62:before {
+    .cardFormHeader__3e8d5.jcb_monochrome__3e8d5:before {
         background-image: url($prefix + "/assets/a4c0bb50800f073359c9caa1bd23f52b.svg");
     }
-    .cardFormHeader_c7dd62.amex_c7dd62:before {
+    .cardFormHeader__3e8d5.amex__3e8d5:before {
         background-image: url($prefix + "/assets/e6f5fdb421197ac145651a603b2a4ca1.svg");
     }
-    .cardFormHeader_c7dd62.amex_monochrome_c7dd62:before {
+    .cardFormHeader__3e8d5.amex_monochrome__3e8d5:before {
         background-image: url($prefix + "/assets/66252c929725c13b887842fc14122de9.svg");
     }
-    .cardFormHeader_c7dd62.mastercard_c7dd62:before {
+    .cardFormHeader__3e8d5.mastercard__3e8d5:before {
         background-image: url($prefix + "/assets/8859268fe0da6c1d43120cc61af43cb2.svg");
     }
-    .cardFormHeader_c7dd62.mastercard_monochrome_c7dd62:before {
+    .cardFormHeader__3e8d5.mastercard_monochrome__3e8d5:before {
         background-image: url($prefix + "/assets/5fc1cc70085cd310fe4078fdb6130259.svg");
     }
-    .cardFormHeader_c7dd62.visa_c7dd62:before {
+    .cardFormHeader__3e8d5.visa__3e8d5:before {
         background-image: url($prefix + "/assets/46bbfc06391fb63686e04c31a0f5d393.svg");
     }
-    .cardFormHeader_c7dd62.visa_monochrome_c7dd62:before {
+    .cardFormHeader__3e8d5.visa_monochrome__3e8d5:before {
         background-image: url($prefix + "/assets/6e3349b7a97ffa4e40e032748de881aa.svg");
     }
-    .cardFormHeader_c7dd62.discover_c7dd62:before {
+    .cardFormHeader__3e8d5.discover__3e8d5:before {
         background-image: url($prefix + "/assets/151e9174cffc5d38d6ce34b0e119b613.svg");
     }
-    .cardFormHeader_c7dd62.discover_monochrome_c7dd62:before {
+    .cardFormHeader__3e8d5.discover_monochrome__3e8d5:before {
         background-image: url($prefix + "/assets/3bed510362f6ace8c0a0a3d3089a8ea8.svg");
     }
-    .cardFormHeader_c7dd62.dinersclub_c7dd62:before {
+    .cardFormHeader__3e8d5.dinersclub__3e8d5:before {
         background-image: url($prefix + "/assets/1192c04cdb47505dbb57fba293b49956.svg");
     }
-    .cardFormHeader_c7dd62.dinersclub_monochrome_c7dd62:before {
+    .cardFormHeader__3e8d5.dinersclub_monochrome__3e8d5:before {
         background-image: url($prefix + "/assets/7e4ced9a6e6936b22e821a0f739bef36.svg");
     }
     .imageUnverified-27S_KF {
         background-image: url($prefix + "/assets/9ee155142daa13a74e603cc1c1bad485.svg");
     }
-    .header_a50853 {
+    .header__6fd0e {
         background:
             center 15%/90% auto url($prefix + "/assets/a81e1a44f42b5939d6e007d37b4fb48c.svg") no-repeat,
             linear-gradient(359.37deg, rgba(0, 0, 0, 0.5) 12.68%, hsla(0, 0%, 100%, 0) 50.4%),
@@ -76,122 +76,122 @@ $prefix: "https://canary.discord.com";
                 var(--premium-tier-0-header-gradient-5) 71.4%
             );
     }
-    .invalidPoop_ff31dd {
+    .invalidPoop__857bf {
         background-image: url($prefix + "/assets/9a31e0f65d520cc12d7f42374d59a2d1.svg");
     }
-    .guildIconExpired_b9fe76 {
+    .guildIconExpired_d5f3cd {
         background-image: url($prefix + "/assets/9a31e0f65d520cc12d7f42374d59a2d1.svg");
     }
-    .invalid_b5b752 {
+    .invalid_ff4e03 {
         background-image: url($prefix + "/assets/9a31e0f65d520cc12d7f42374d59a2d1.svg");
     }
-    .artworkSpotifySessionEnded_cdcad9 {
+    .artworkSpotifySessionEnded__4d3fa {
         background-image: url($prefix + "/assets/1e3eefd7b16f4e6b59faa3e3d48f582f.svg");
     }
-    .sadImage_e78f9e {
+    .sadImage__29ebd {
         background-image: url($prefix + "/assets/28e8c52ad284779a9272dad02a70fa4e.svg");
     }
-    .imageLoading_b000dd {
+    .imageLoading__1859b {
         background-image: url($prefix + "/assets/56b42ec7fdca5d48afd672a7163b9c06.png");
     }
     .art-1bAcVF {
         background-image: url($prefix + "/assets/f0fd53980da8cde41a97db3cf20de65d.svg");
     }
-    .emptyState_f4e139 {
+    .emptyState_ac6cb0 {
         background-image: url($prefix + "/assets/e61baf173edfbd88037ecdd2c793834e.svg");
     }
-    .verification_ce1f6e .image_ce1f6e {
+    .verification_dede4b .image_dede4b {
         background-image: url($prefix + "/assets/d5bd759fc308772cbf277188cabdcc8f.svg");
     }
-    .verificationBlock__2ee71 .image_ce1f6e.email__44f2f {
+    .verificationBlock__2ee71 .image_dede4b.email__44f2f {
         background-image: url($prefix + "/assets/ad21e9327e71ab990fd1d7fb8cea66fc.svg");
     }
-    .verificationBlock__2ee71 .image_ce1f6e.phone__0b460 {
+    .verificationBlock__2ee71 .image_dede4b.phone__0b460 {
         background-image: url($prefix + "/assets/0eeb095cd923afdf420687347dc673ff.svg");
     }
-    .activityInviteEducationArrow_d7ebeb {
+    .activityInviteEducationArrow_b88801 {
         background-image: url($prefix + "/assets/ce73613685f715d326709ec90c1cd741.svg");
     }
-    .endContainer_bad108:after {
+    .endContainer__2dc39:after {
         background-image: url($prefix + "/assets/be5f088125f778701a7e4fad471a45da.svg");
     }
-    .image_fea561 {
+    .image__5b754 {
         background-image: url($prefix + "/assets/03e1ac95e0dd757f16dc200bf6af9ba3.svg");
     }
-    .image_b9693a {
+    .image__7184c {
         background-image: url($prefix + "/assets/f6a272d9794eb33939cf1baa953ceb3e.svg");
     }
-    .searchIndexBackground_e1f40e {
+    .searchIndexBackground_e1fee6 {
         background-image: url($prefix + "/assets/63a3f34794926b2ee4e5ef22b5c31e15.svg");
     }
-    .resultsBlockedImage_a9e225 {
+    .resultsBlockedImage_c68065 {
         background-image: url($prefix + "/assets/b21bd7d0978d3e2d41eefa8993333435.svg");
     }
-    .noResultsImage_c2b47d {
+    .noResultsImage_a9e706 {
         background-image: url($prefix + "/assets/8f79e7f01dbb1afeb122cb3e8c4a342f.svg");
     }
-    .noResultsImage_c2b47d.alt_c2b47d {
+    .noResultsImage_a9e706.alt_a9e706 {
         background-image: url($prefix + "/assets/f203f5736b9aa0178751342dcc73548a.svg");
     }
-    .errorImage_c2b47d {
+    .errorImage_a9e706 {
         background-image: url($prefix + "/assets/7dfacc7529214e45b9e3cfd50979edea.svg");
     }
-    .emptyPreviewImage_ed81cc {
+    .emptyPreviewImage__04666 {
         background-image: url($prefix + "/assets/66b66e8ee672e7d5c3edd7d139efe166.svg");
     }
-    .notFriends_e6af9c .errorStateIcon_e6af9c {
+    .notFriends_cba592 .errorStateIcon_cba592 {
         background-image: url($prefix + "/assets/35000dd88d1b338a790f3e387cbd7e7a.svg");
     }
-    .noFriends_e6af9c .errorStateIcon_e6af9c {
+    .noFriends_cba592 .errorStateIcon_cba592 {
         background-image: url($prefix + "/assets/1dabb8ee5d7cb5137c06f958e0091573.svg");
     }
-    .partyFull_e6af9c .errorStateIcon_e6af9c {
+    .partyFull_cba592 .errorStateIcon_cba592 {
         background-image: url($prefix + "/assets/25f3555f54d3c872f0ac7a5922c8eccf.svg");
     }
-    .noResults_e6af9c .errorStateIcon_e6af9c {
+    .noResults_cba592 .errorStateIcon_cba592 {
         background-image: url($prefix + "/assets/03e1ac95e0dd757f16dc200bf6af9ba3.svg");
     }
-    .unknown_b09fe8 {
+    .unknown__5017b {
         background-image: url($prefix + "/assets/81673077ca178aa1173cfdca182420d8.svg");
     }
     .quickSelectArrow__5988b {
         background: url($prefix + "/assets/fb792f56515490f402b731abf6af5d45.svg") 50% no-repeat;
     }
-    .emptyIconStreamerMode_e4be58 {
+    .emptyIconStreamerMode__9d78f {
         background-image: url($prefix + "/assets/16cbaa97e5daa42bbc69cf064011be69.svg");
     }
-    .emptyIconGuilds_e4be58 {
+    .emptyIconGuilds__9d78f {
         background-image: url($prefix + "/assets/3ba82b28fba53cc606486b5cf48c3c30.svg");
     }
-    .emptyIconFriends_e4be58 {
+    .emptyIconFriends__9d78f {
         background-image: url($prefix + "/assets/7fcb750721a08b543ba49fb04bd04158.svg");
     }
-    .streamerModeEnabledImage_c50c8b {
+    .streamerModeEnabledImage_aa3ffd {
         background-image: url($prefix + "/assets/80cb895c1ed74292d5cf0acabe103f32.svg");
     }
     .tier1Banner-LvpkWu {
         background-image: url($prefix + "/assets/ea6fbee8930d2ece33ce9c1cabb73304.svg");
     }
-    .emptyWumpus_f1629a {
+    .emptyWumpus_adb41f {
         background: url($prefix + "/assets/e0989b9d43cd9ca4417b49f4f8fbebc6.svg");
     }
-    .krispLogo_adcaac {
+    .krispLogo_e131a9 {
         background-image: url($prefix + "/assets/73c1c05c8458288db873591e1f6ee5a9.svg");
     }
-    .imageUploaderIcon_de76e4 {
+    .imageUploaderIcon_e4d0bf {
         background-image: url($prefix + "/assets/4a1000a95b1aad334e98f9d15b9d0ec4.svg");
     }
     .noProductsContainer_ed990f {
         background: var(--background-modifier-hover) url($prefix + "/assets/80b29ef69b7a8039d6f1276d5acc31eb.png") 16px 16px/702px 108px
             no-repeat;
     }
-    .imageUploaderInnerSquare_e95c0f {
+    .imageUploaderInnerSquare__97197 {
         background-image: url($prefix + "/assets/2366391afb15ed6c2a019a0c0caa0797.svg");
     }
     .imageUploaderInnerSquare_b2b948 {
         background-image: url($prefix + "/assets/2366391afb15ed6c2a019a0c0caa0797.svg");
     }
-    .footerImage_fab929 {
+    .footerImage__98b95 {
         background-image: url($prefix + "/assets/d89511b11686ab5c942b3ef900e3d0eb.svg");
     }
     .imageUpgrade-14Nm12 {
@@ -242,10 +242,10 @@ $prefix: "https://canary.discord.com";
     .header-13P3fr {
         background-image: url($prefix + "/assets/579816de0b3fa8045cb75173f0ce1c90.svg");
     }
-    .image_f5cdb8 {
+    .image_a202d2 {
         background-image: url($prefix + "/assets/ad21e9327e71ab990fd1d7fb8cea66fc.svg");
     }
-    .emptyStateImage_e8af36 {
+    .emptyStateImage_d4883c {
         background: url($prefix + "/assets/e0989b9d43cd9ca4417b49f4f8fbebc6.svg");
     }
     .guildHeaderBackground__04920 {
@@ -254,7 +254,7 @@ $prefix: "https://canary.discord.com";
     .emptyGuilds__164f0 {
         background-image: url($prefix + "/assets/9eccd9710a1b3c2b7127bc1ab191a423.svg");
     }
-    .previewImage_ff1ac9 {
+    .previewImage_d41d5f {
         background-image: url($prefix + "/assets/ca9e397003df8b46709315d7a248c7de.svg");
     }
     .dragged-S44x-A {
@@ -274,78 +274,78 @@ $prefix: "https://canary.discord.com";
     }
 }
 
-:is(.themeOverrideLight_eebd33.icon_eebd33, .theme-light .icon_eebd33) {
-    &.targetAll_eebd33 {
+:is(.themeOverrideLight__43dab.icon__43dab, .theme-light .icon__43dab) {
+    &.targetAll__43dab {
         background: url($prefix + "/assets/22fd0ab3562af24ea964465bb65531aa.svg");
     }
-    &.targetBan_eebd33 {
+    &.targetBan__43dab {
         background: url($prefix + "/assets/fd541825b6853aaae233ad9d83e05a18.svg");
     }
-    &.targetChannel_eebd33 {
+    &.targetChannel__43dab {
         background: url($prefix + "/assets/528ae525a9823affbcd2a35bd20573b0.svg");
     }
-    &.targetGuild_eebd33 {
+    &.targetGuild__43dab {
         background: url($prefix + "/assets/448b698d906ab4d93b609282595a1c9d.svg");
     }
-    &.targetEmoji_eebd33 {
+    &.targetEmoji__43dab {
         background: url($prefix + "/assets/858ab2bdee17ca226df85e23263bcf3a.svg");
     }
-    &.targetSticker_eebd33 {
+    &.targetSticker__43dab {
         background: url($prefix + "/assets/da5f0aa4b5ccf0165b4220ba9929ea59.svg");
     }
-    &.targetIntegration_eebd33 {
+    &.targetIntegration__43dab {
         background: url($prefix + "/assets/993b5f52b8bd8d1c1c34cac05015c331.svg");
     }
-    &.targetInvite_eebd33 {
+    &.targetInvite__43dab {
         background: url($prefix + "/assets/d0dc8a4c8ea55b119c5c2cccf69b031f.svg");
     }
-    &.targetMemberRole_eebd33 {
+    &.targetMemberRole__43dab {
         background: url($prefix + "/assets/00124e254d0d86c37f6d02ec0c5b1e02.svg");
     }
-    &.targetMember_eebd33 {
+    &.targetMember__43dab {
         background: url($prefix + "/assets/e2c0846875f889524e3d60e7d25afa55.svg");
     }
-    &.targetPermission_eebd33 {
+    &.targetPermission__43dab {
         background: url($prefix + "/assets/35de2007bfe0db9821881321d8b7c1fe.svg");
     }
-    &.targetRole_eebd33 {
+    &.targetRole__43dab {
         background: url($prefix + "/assets/9aa6e9df74888ec09885bb08341800be.svg");
     }
-    &.targetOnboarding_eebd33 {
+    &.targetOnboarding__43dab {
         background: url($prefix + "/assets/30d336e8dfc82755e571eb207476343e.svg");
     }
-    &.targetVanityUrl_eebd33 {
+    &.targetVanityUrl__43dab {
         background: url($prefix + "/assets/bef4eebd4f9e00aabbfa7de1949c8565.svg");
     }
-    &.targetWebhook_eebd33 {
+    &.targetWebhook__43dab {
         background: url($prefix + "/assets/210ac667f45d13bc52020744f008b1ed.svg");
     }
-    &.targetWidget_eebd33 {
+    &.targetWidget__43dab {
         background: url($prefix + "/assets/03f717eddad9ac74a1900254625657cf.svg");
     }
-    &.targetMessage_eebd33 {
+    &.targetMessage__43dab {
         background: url($prefix + "/assets/aa9f9c29b51e414f0476d4388031aaf4.svg");
     }
-    &.targetStageInstance_eebd33 {
+    &.targetStageInstance__43dab {
         background: url($prefix + "/assets/dfad85fc7c072498298077f68cf006ca.svg");
     }
-    &.targetGuildScheduledEvent_eebd33 {
+    &.targetGuildScheduledEvent__43dab {
         background: url($prefix + "/assets/7093e58edcd5202a129a6e4fbf427c6d.svg");
     }
-    &.thread_eebd33 {
+    &.thread__43dab {
         background: url($prefix + "/assets/c254ffdde9bc5c90c5ec5d9e11dbf382.svg");
     }
-    &.applicationCommand_eebd33 {
+    &.applicationCommand__43dab {
         background: url($prefix + "/assets/561a626f671b8fd8f0c2e85c97df9b04.svg");
     }
-    &.autoModerationBlockMessage_eebd33,
-    &.autoModerationRule_eebd33 {
+    &.autoModerationBlockMessage__43dab,
+    &.autoModerationRule__43dab {
         background: url($prefix + "/assets/210ac667f45d13bc52020744f008b1ed.svg");
     }
-    &.targetGuildHome_eebd33 {
+    &.targetGuildHome__43dab {
         background: url($prefix + "/assets/eeaa7c1199e8f4cdb46de98c9b924edf.svg");
     }
-    &.targetGuildSoundboard_eebd33 {
+    &.targetGuildSoundboard__43dab {
         background: url($prefix + "/assets/43c3103dc78b8ddb331c6de385183e95.svg");
     }
 }

--- a/scss/part/_icons.scss
+++ b/scss/part/_icons.scss
@@ -3,31 +3,31 @@
 @use "../top/shortcutIcon" as sc;
 
 // Top bar (not in DMs, not in VC)
-.toolbar_e44302:not(.videoControls_dd069c .toolbar_e44302) {
+.toolbar__9293f:not(.videoControls_bfe55a .toolbar__9293f) {
     // Move help icon
-    .anchor_af404b .iconWrapper_e44302:only-of-type {
+    .anchor_edefb8 .iconWrapper__9293f:only-of-type {
         $image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAYUExURXsAewAAAHt9e3t9AP//AL2+vf///wAAALUfaqUAAAAIdFJOU/////////8A3oO9WQAAAAlwSFlzAAALbAAAC2wBUklGNQAAALBJREFUOE/Fz8EWgzAIRFEkifn/Py4BJDNx0VVPWbQe3xWNzC/zByBy5VXOAURNEGGwug0SAtltNkEQvfXegACI3n3WVZANnv32eOyI8xTY76+XxH3/hW6VPiIB9hb7FQHu92x9ALB1l99u8XXeGag6ecDqA44p1xhJfLwrHNPAfd9FsCN4CPUEIqpFqAeY68Ei1BMQoV4ACHUARagTSEL9AE6ov4CR/M95g2N+Dub8AOK+FDIVX50FAAAAAElFTkSuQmCC");
-        @include sc.makeIcon(50px, auto, ".icon_e44302", $image);
+        @include sc.makeIcon(50px, auto, ".icon__9293f", $image);
         top: $window-top;
     }
 
     // Move show/hide member list button
-    .iconWrapper_e44302:has([d^="M14 8.00598"]) {
+    .iconWrapper__9293f:has([d^="M14 8.00598"]) {
         $image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAhUExURXt9e72+vf///wAAAAB9ewD//wAAewAA/wD/AAB9AAAAAGqqxmQAAAALdFJOU/////////////8ASk8B8gAAAAlwSFlzAAALbAAAC2wBUklGNQAAAMhJREFUOE+FkwkSxCAIBInukfj/B+9wVRSI22XlkFaRGBoOJbRbroCOQKMu/RLFvUVoEajZuJsk2MIGvwehz5TCa6IW3jp6I8hWNgK6P18gTw+Cz/EgcPZbgQN/BN9HJVgJjULgySeyEIHAR8KFAsSP7oImt4I4VhHBhkQkDRbyaVLguGB5BUpB5haCcJ4qWIIgCNelgqL/wCJU3AIe8JvEhkKg2BBwTFKQG3X+GCRxvKSGC+KY3qoS4TKrYBlFLI4lbNsJCY/xAw14DnPdYrX4AAAAAElFTkSuQmCC");
-        @include sc.makeIcon(auto, 50px, ".icon_e44302", $image);
+        @include sc.makeIcon(auto, 50px, ".icon__9293f", $image);
     }
 }
 
 // Gift nitro button
-.buttons_d0696b > .button_dd4f85 {
+.buttons__74017 > .button__201d5 {
     $image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAhUExURYCAgMDAwACAgAAA/wCAAAAAAP////8AAIAAAAAAgAAAAKu4jYQAAAALdFJOU/////////////8ASk8B8gAAAAlwSFlzAAALbAAAC2wBUklGNQAAARFJREFUOE9t0guShCAMBNDwU+H+B97uTkAGN1U6FP0IOGpjlZnxUsUUag0xm5JZTlZyzi+JQcS8as2l1jrJ/JmxE1XzRPdh1/0lyhZ47uckjeHb4b6va5FGkDt2ecEDEKSlltmBx3BghuwhAEGcGh+k9tq0TYAoB9qi9gB2OSgvKNyj194d5A/oBQURz5omAHGAtRLR4T+AvOOoDuKQG8gC3oHpB5gadADF3w6YgxBg/AWJyxxoaIw2kDjbOv8ovJwFSAgU2wsoAqBmTMCXdYIV7wBCzTWcMQA/ugnQAxnKMxVzAJ5J69QhMpWDMVoQ3ncQnwJvTlQRxgFQAhs54gUWOeINBDniHyByxAcgiUHUGH+i9ROnjFTAkgAAAABJRU5ErkJggg==");
-    @include sc.makeIcon(50px, auto, ".buttonWrapper_cecf00", $image);
+    @include sc.makeIcon(50px, auto, ".buttonWrapper__24af7", $image);
     top: $window-top + 90px;
 
-    .button_d0696b {
+    .button__74017 {
         margin: 0;
 
-        .buttonWrapper_cecf00 {
+        .buttonWrapper__24af7 {
             padding: 0;
             margin: 0;
             display: flex;

--- a/scss/part/_scrollbar.scss
+++ b/scss/part/_scrollbar.scss
@@ -2,7 +2,7 @@
 @use "../top/boxes" as boxes;
 
 // Scrollbars always visible
-:is(.fade_eed6a8, .fade_c49869) {
+:is(.fade__99f8c, .fade_d125d2) {
     &::-webkit-scrollbar-thumb,
     &::-webkit-scrollbar-track {
         visibility: visible;
@@ -10,15 +10,15 @@
 }
 
 // Main scrollbars
-.scrollerBase_eed6a8,
-.scrollerBase_c49869,
+.scrollerBase__99f8c,
+.scrollerBase_d125d2,
 // Chatbox scrollbar
-.scrollableContainer_d0696b,
+.scrollableContainer__74017,
 // Textbox scrollbar
 .webkit__8d35a,
 // Spooky scary scrollbars
-.scrollbarGhostHairline_c858ce {
-    &:not(.none_eed6a8, .none_c49869)::-webkit-scrollbar {
+.scrollbarGhostHairline__506b3 {
+    &:not(.none__99f8c, .none_d125d2)::-webkit-scrollbar {
         width: 18px;
     }
 
@@ -34,7 +34,7 @@
 }
 
 // Code view scrollbar
-.codeView_ad9cbd::-webkit-scrollbar-track {
+.codeView__4d95d::-webkit-scrollbar-track {
     margin: 0;
 }
 

--- a/scss/plugin/_DateViewer.scss
+++ b/scss/plugin/_DateViewer.scss
@@ -6,7 +6,7 @@
 
 $dv-width: 80px;
 
-.members_cbd271 {
+.members_c8ffbb {
     margin-bottom: unset;
 }
 
@@ -38,12 +38,12 @@ $dv-width: 80px;
     }
 }
 
-body #app-mount:has(#dv-mount) .guilds_a4d4d9 {
+body #app-mount:has(#dv-mount) .guilds_c48ade {
     height: calc(100vw - $panel-width - $dv-width) !important;
     left: calc(100vw - $panel-width - $dv-width);
 }
 
-.appMount_ea7e65:has(#dv-mount) .panels_a4d4d9 {
+.appMount__51fd7:has(#dv-mount) .panels_c48ade {
     left: calc(100vw - $panel-width - $dv-width);
     &,
     &::before {

--- a/scss/plugin/_HorizontalServerList.scss
+++ b/scss/plugin/_HorizontalServerList.scss
@@ -4,35 +4,35 @@
 // Override HSL options
 
 // Override HSL
-body #app-mount .guilds_a4d4d9 {
+body #app-mount .guilds_c48ade {
     // Leave gap for control panel
     height: calc(100vw - $panel-width) !important;
     left: calc(100vw - $panel-width);
     z-index: 0;
 
-    .wrapper_bc7085 > .listItem_c96c45,
-    .scroller_fea3ef > div > .listItem_c96c45,
-    .scroller_fea3ef > .listItem_c96c45 {
+    .wrapper__48112 > .listItem__650eb,
+    .scroller_ef3116 > div > .listItem__650eb,
+    .scroller_ef3116 > .listItem__650eb {
         left: -7px;
         position: relative;
     }
 
-    .scroller_fea3ef > div > .listItem_c96c45 > .pill_a5ad63 {
+    .scroller_ef3116 > div > .listItem__650eb > .pill_e5445c {
         bottom: -20px !important;
     }
 }
 
 // Opened folder icon
-#app-mount .expandedFolderBackground_bc7085:not(.collapsed_bc7085) + .listItem_c96c45 {
+#app-mount .expandedFolderBackground__48112:not(.collapsed__48112) + .listItem__650eb {
     @include boxes.inset;
-    .expandedFolderIconWrapper_bc7085 {
+    .expandedFolderIconWrapper__48112 {
         display: none;
     }
 }
 
-#app-mount .guilds_a4d4d9 {
+#app-mount .guilds_c48ade {
     // Servers in opened folder
-    .wrapper_bc7085 ul[role="group"] {
+    .wrapper__48112 ul[role="group"] {
         gap: 0px;
         align-items: center;
     }
@@ -45,11 +45,11 @@ body #app-mount .guilds_a4d4d9 {
 
 // Titlebar on macOS
 html.platform-osx #app-mount {
-    .base_a4d4d9 {
+    .base_c48ade {
         top: 0 !important;
     }
 
-    .typeMacOS_a934d8 {
+    .typeMacOS__421ed {
         width: auto;
     }
 }

--- a/scss/plugin/_chatboxbuttons.scss
+++ b/scss/plugin/_chatboxbuttons.scss
@@ -6,7 +6,7 @@
 // BD: Translator, InvisibleTyping
 
 // SendTimestamps, SilentTyping
-.channelTextArea_a7d72e div[style="display: flex;"],
+.channelTextArea_f75fb0 div[style="display: flex;"],
 // InvisibleTyping
 .invisible-typing-button {
     @include boxes.clickable;

--- a/scss/plugin/_userpanel.scss
+++ b/scss/plugin/_userpanel.scss
@@ -4,16 +4,16 @@
 // Replugged:       SpotifyModal
 // Vencord:         SpotifyModal
 
-.panels_a4d4d9 {
-    &:has(.container_adcaac, .activityPanel_a4d4d9, .container_b2ca13, #spotify-modal-root, #vc-spotify-player) {
+.panels_c48ade {
+    &:has(.container_e131a9, .activityPanel_c48ade, .container__37e49, #spotify-modal-root, #vc-spotify-player) {
         height: auto;
     }
 
-    :is(.container_adcaac, .activityPanel_a4d4d9, .container_b2ca13, #spotify-modal-root, #vc-spotify-player) {
+    :is(.container_e131a9, .activityPanel_c48ade, .container__37e49, #spotify-modal-root, #vc-spotify-player) {
         border-bottom: 0;
     }
 
-    &:not(:has(.container_adcaac, .activityPanel_a4d4d9, .container_b2ca13, #spotify-modal-root, #vc-spotify-player)) {
+    &:not(:has(.container_e131a9, .activityPanel_c48ade, .container__37e49, #spotify-modal-root, #vc-spotify-player)) {
         border-left: 0;
         &::before {
             border-left: 0;

--- a/scss/top/_folderIcon.scss
+++ b/scss/top/_folderIcon.scss
@@ -20,7 +20,7 @@ $backgrounds: (
 
 @mixin folderIcon() {
     @for $i from 1 through 14 {
-        .wrapper_bc7085:nth-child(#{$i}) .expandedFolderBackground_bc7085 + .listItem_c96c45 {
+        .wrapper__48112:nth-child(#{$i}) .expandedFolderBackground__48112 + .listItem__650eb {
             background: url("https://saltssaumure.github.io/w9x-discord-theme/img/icon/" + nth($backgrounds, $i) + ".avif")
                 center
                 no-repeat;


### PR DESCRIPTION
Updated classes for new Discord update.

Should fix https://github.com/Saltssaumure/w9x-discord-theme/issues/33.

Changes appear working for me on stable 364202 (37108ad) using Vencord 4f5ebec (Vesktop v1.5.4).